### PR TITLE
Skip history snapshots for typing updates

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -79,13 +79,15 @@ async function pushHistory(newBlocks) {
     pushHistory(blocks);
   }
 
-  async function updateBlockHandler(event, pushToHistory = true) {
-    const idx = blocks.findIndex(b => b.id === event.detail.id);
+  async function updateBlockHandler(event) {
+    const { pushToHistory = true, ...detail } = event.detail || {};
+
+    const idx = blocks.findIndex(b => b.id === detail.id);
     if (idx === -1) return;
 
-    const updatedBlock = { 
-      ...blocks[idx], 
-      ...event.detail, 
+    const updatedBlock = {
+      ...blocks[idx],
+      ...detail,
       _version: pushToHistory ? (blocks[idx]._version || 0) + 1 : blocks[idx]._version || 0
     };
 

--- a/src/BACKUPS/CanvasMode.svelte
+++ b/src/BACKUPS/CanvasMode.svelte
@@ -31,7 +31,7 @@
   }
 
   function updateBlockHandler(event) {
-   dispatch ('update', event.detail);
+   dispatch('update', { ...event.detail });
   }
 
 
@@ -174,7 +174,7 @@
             initialTextColor={block.textColor}
             initialContent={block.content}
             on:delete={deleteBlockHandler}
-            on:update={e => updateBlockHandler(e, false)}
+            on:update={updateBlockHandler}
 
           />
         {:else if block.type === 'image'}
@@ -197,7 +197,7 @@
             initialTextColor={block.textColor}
             initialContent={block.content}
             on:delete={deleteBlockHandler}
-            on:update={e => updateBlockHandler(e, false)}
+            on:update={updateBlockHandler}
 
           />
         {:else if block.type === 'music'}

--- a/src/BACKUPS/SimpleNoteMode.svelte
+++ b/src/BACKUPS/SimpleNoteMode.svelte
@@ -8,8 +8,8 @@
     dispatch('delete', { id });
   }
 
-  function updateBlock(id, updates) {
-    dispatch('update', { id, ...updates });
+  function updateBlock(id, updates, { pushToHistory = true } = {}) {
+    dispatch('update', { id, ...updates, pushToHistory });
   }
 
   function autoResize(textarea) {
@@ -216,7 +216,7 @@ li {
             style="overflow:hidden;"
             on:input={(e) => {
               autoResize(e.target);
-              updateBlock(block.id, { content: e.target.value });
+              updateBlock(block.id, { content: e.target.value }, { pushToHistory: false });
             }}
             on:focus={(e) => focusScroll(e.target)}
             placeholder="Type your note here..."

--- a/src/components/TexteBlock.svelte
+++ b/src/components/TexteBlock.svelte
@@ -21,8 +21,8 @@
   let offset = { x: 0, y: 0 };
   let resizeStart = { x: 0, y: 0, width: 0, height: 0 };
 
-  function sendUpdate() {
-    dispatch('update', { id, position, size, bgColor, textColor, content });
+  function sendUpdate({ pushToHistory = true } = {}) {
+    dispatch('update', { id, position, size, bgColor, textColor, content, pushToHistory });
   }
 
   // Drag start
@@ -219,7 +219,7 @@
     <textarea
       spellcheck="false"
       bind:value={content}
-      on:input={sendUpdate}
+      on:input={() => sendUpdate({ pushToHistory: false })}
     ></textarea>
   </div>
 

--- a/src/components/TexteClean.svelte
+++ b/src/components/TexteClean.svelte
@@ -26,9 +26,9 @@
     if (editableDiv) editableDiv.innerText = content;
   });
 
-  function sendUpdate() {
+  function sendUpdate({ pushToHistory = true } = {}) {
     content = editableDiv.innerText;
-    dispatch('update', { id, position, size, bgColor, textColor, content });
+    dispatch('update', { id, position, size, bgColor, textColor, content, pushToHistory });
   }
 
   // Drag start
@@ -226,7 +226,7 @@
     bind:this={editableDiv}
     class="editable"
     spellcheck="false"
-    on:input={sendUpdate}
+    on:input={() => sendUpdate({ pushToHistory: false })}
   ></div>
 
   <div


### PR DESCRIPTION
## Summary
- allow the app-level block updater to respect a pushToHistory flag from components
- adjust text components to skip history snapshots during typing while still dispatching autosaves
- ensure canvas and simple modes forward the pushToHistory flag through their update events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e01832bb88832eb306746f4e9d90cf