### PR TITLE
Add block-level history triggers for snapshots

### DIFF
--- a/src/BACKUPS/SimpleNoteMode.svelte
+++ b/src/BACKUPS/SimpleNoteMode.svelte
@@ -8,8 +8,16 @@
     dispatch('delete', { id });
   }
 
-  function updateBlock(id, updates, { pushToHistory = true } = {}) {
-    dispatch('update', { id, ...updates, pushToHistory });
+  function updateBlock(id, updates, { pushToHistory, changedKeys } = {}) {
+    const detail = { id, ...updates };
+    const effectiveKeys = Array.isArray(changedKeys) && changedKeys.length
+      ? changedKeys
+      : Object.keys(updates || {});
+
+    if (effectiveKeys.length) detail.changedKeys = effectiveKeys;
+    if (pushToHistory !== undefined) detail.pushToHistory = pushToHistory;
+
+    dispatch('update', detail);
   }
 
   function autoResize(textarea) {
@@ -216,7 +224,7 @@ li {
             style="overflow:hidden;"
             on:input={(e) => {
               autoResize(e.target);
-              updateBlock(block.id, { content: e.target.value }, { pushToHistory: false });
+              updateBlock(block.id, { content: e.target.value }, { pushToHistory: false, changedKeys: ['content'] });
             }}
             on:focus={(e) => focusScroll(e.target)}
             placeholder="Type your note here..."

--- a/src/components/EmbedBlock.svelte
+++ b/src/components/EmbedBlock.svelte
@@ -23,8 +23,9 @@
   let offset = { x: 0, y: 0 }, resizeStart = {};
   let showSettings = false;
 
-  function sendUpdate() {
-    dispatch('update', {
+  function sendUpdate(changedKeys, { pushToHistory } = {}) {
+    const effectiveKeys = Array.isArray(changedKeys) && changedKeys.length ? changedKeys : [];
+    const detail = {
       id,
       position,
       size,
@@ -32,7 +33,12 @@
       textColor,
       content,
       title
-    });
+    };
+
+    if (effectiveKeys.length) detail.changedKeys = effectiveKeys;
+    if (pushToHistory !== undefined) detail.pushToHistory = pushToHistory;
+
+    dispatch('update', detail);
   }
 
   // Dragging
@@ -64,7 +70,7 @@
     window.removeEventListener('mouseup', onMouseUp);
     window.removeEventListener('touchmove', onMouseMove);
     window.removeEventListener('touchend', onMouseUp);
-    sendUpdate();
+    sendUpdate(['position']);
   }
 
   // Resizing
@@ -98,7 +104,7 @@
     window.removeEventListener('mouseup', onResizeEnd);
     window.removeEventListener('touchmove', onResizing);
     window.removeEventListener('touchend', onResizeEnd);
-    sendUpdate();
+    sendUpdate(['size']);
   }
 
   function deleteBlock() {
@@ -198,8 +204,8 @@
     <span>{title}</span>
     <div class="header-controls" on:mousedown|stopPropagation>
       <button on:click={() => showSettings = !showSettings} class="gear-btn">⚙︎</button>
-      <input type="color" bind:value={bgColor} on:change={sendUpdate} />
-      <input type="color" bind:value={textColor} on:change={sendUpdate} />
+      <input type="color" bind:value={bgColor} on:change={() => sendUpdate(['bgColor'])} />
+      <input type="color" bind:value={textColor} on:change={() => sendUpdate(['textColor'])} />
       <button class="delete-btn" on:click={deleteBlock}>×</button>
     </div>
   </div>
@@ -216,7 +222,7 @@
 
     <label style="padding: 6px;">
       Embed URL:
-      <input type="text" bind:value={content} on:input={sendUpdate} placeholder="https://example.com/embed" />
+      <input type="text" bind:value={content} on:input={() => sendUpdate(['content'])} placeholder="https://example.com/embed" />
     </label>
   </div>
 

--- a/src/components/ImgBlock.svelte
+++ b/src/components/ImgBlock.svelte
@@ -26,8 +26,14 @@
   let resizeStart = { x: 0, y: 0, width: 0, height: 0 };
 
 
-  function sendUpdate() {
-    dispatch('update', { id, position, size, bgColor, textColor, src });
+  function sendUpdate(changedKeys, { pushToHistory } = {}) {
+    const effectiveKeys = Array.isArray(changedKeys) && changedKeys.length ? changedKeys : [];
+    const detail = { id, position, size, bgColor, textColor, src };
+
+    if (effectiveKeys.length) detail.changedKeys = effectiveKeys;
+    if (pushToHistory !== undefined) detail.pushToHistory = pushToHistory;
+
+    dispatch('update', detail);
   }
 
 
@@ -63,7 +69,7 @@
           aspectRatio = targetWidth / targetHeight;   // media content ratio only
 
 
-          sendUpdate();
+          sendUpdate(['src', 'size']);
         };
       } else {
         const videoEl = document.createElement('video');
@@ -83,7 +89,7 @@
           size.width = targetWidth;
           size.height = targetHeight + HEADER_HEIGHT;
 
-          sendUpdate();
+          sendUpdate(['src', 'size']);
         };
       }
     };
@@ -127,7 +133,7 @@ function onMouseUp() {
   window.removeEventListener('mouseup', onMouseUp);
   window.removeEventListener('touchmove', onMouseMove);
   window.removeEventListener('touchend', onMouseUp);
-  sendUpdate();
+  sendUpdate(['position']);
 }
 
 
@@ -177,7 +183,7 @@ function onResizeEnd() {
   window.removeEventListener('mouseup', onResizeEnd);
   window.removeEventListener('touchmove', onResizing);
   window.removeEventListener('touchend', onResizeEnd);
-  sendUpdate();
+  sendUpdate(['size']);
 }
 
 
@@ -290,8 +296,8 @@ function onResizeEnd() {
     <div>image</div>
     <div class="header-controls" on:mousedown|stopPropagation>
 
-        <input type="color" bind:value={bgColor} on:change={sendUpdate}/>
-        <input type="color" bind:value={textColor} on:change={sendUpdate}/>
+        <input type="color" bind:value={bgColor} on:change={() => sendUpdate(['bgColor'])}/>
+        <input type="color" bind:value={textColor} on:change={() => sendUpdate(['textColor'])}/>
 
       <label title="Change Image" class="media-btn">
         <input type="file" accept="image/*,video/mp4" on:change={onMediaChange} />

--- a/src/components/MusicBlock.svelte
+++ b/src/components/MusicBlock.svelte
@@ -22,8 +22,9 @@
   let offset = { x: 0, y: 0 }, resizeStart = {};
   let showSettings = false;
 
-  function sendUpdate() {
-    dispatch('update', {
+  function sendUpdate(changedKeys, { pushToHistory } = {}) {
+    const effectiveKeys = Array.isArray(changedKeys) && changedKeys.length ? changedKeys : [];
+    const detail = {
       id,
       position,
       size,
@@ -31,7 +32,12 @@
       textColor,
       trackUrl,
       title
-    });
+    };
+
+    if (effectiveKeys.length) detail.changedKeys = effectiveKeys;
+    if (pushToHistory !== undefined) detail.pushToHistory = pushToHistory;
+
+    dispatch('update', detail);
   }
 
   // Handle local audio file upload
@@ -39,7 +45,7 @@
     const file = event.target.files?.[0];
     if (file) {
       trackUrl = URL.createObjectURL(file);
-      sendUpdate();
+      sendUpdate(['trackUrl']);
     }
   }
 
@@ -72,7 +78,7 @@
     window.removeEventListener('mouseup', onMouseUp);
     window.removeEventListener('touchmove', onMouseMove);
     window.removeEventListener('touchend', onMouseUp);
-    sendUpdate();
+    sendUpdate(['position']);
   }
 
   // Resize start
@@ -106,7 +112,7 @@
     window.removeEventListener('mouseup', onResizeEnd);
     window.removeEventListener('touchmove', onResizing);
     window.removeEventListener('touchend', onResizeEnd);
-    sendUpdate();
+    sendUpdate(['size']);
   }
 
   function deleteBlock() {
@@ -204,8 +210,8 @@
     <span>{title}</span>
     <div class="header-controls" on:mousedown|stopPropagation>
       <button on:click={() => showSettings = !showSettings} class="gear-btn">⚙︎</button>
-      <input type="color" bind:value={bgColor} on:change={sendUpdate} />
-      <input type="color" bind:value={textColor} on:change={sendUpdate} />
+      <input type="color" bind:value={bgColor} on:change={() => sendUpdate(['bgColor'])} />
+      <input type="color" bind:value={textColor} on:change={() => sendUpdate(['textColor'])} />
       <button class="delete-btn" on:click={deleteBlock}>×</button>
     </div>
   </div>
@@ -219,12 +225,12 @@
       <audio controls src={trackUrl}></audio>
       <label>
         Title:
-        <input type="text" bind:value={title} on:input={sendUpdate} />
+        <input type="text" bind:value={title} on:input={() => sendUpdate(['title'])} />
       </label>
       <br />
       <label>
         Track URL:
-        <input type="text" bind:value={trackUrl} on:input={sendUpdate} placeholder="https://example.com/song.mp3" />
+        <input type="text" bind:value={trackUrl} on:input={() => sendUpdate(['trackUrl'])} placeholder="https://example.com/song.mp3" />
       </label>
       <br />
       <label>

--- a/src/components/TexteBlock.svelte
+++ b/src/components/TexteBlock.svelte
@@ -21,8 +21,14 @@
   let offset = { x: 0, y: 0 };
   let resizeStart = { x: 0, y: 0, width: 0, height: 0 };
 
-  function sendUpdate({ pushToHistory = true } = {}) {
-    dispatch('update', { id, position, size, bgColor, textColor, content, pushToHistory });
+  function sendUpdate(changedKeys, { pushToHistory } = {}) {
+    const effectiveKeys = Array.isArray(changedKeys) && changedKeys.length ? changedKeys : [];
+    const detail = { id, position, size, bgColor, textColor, content };
+
+    if (effectiveKeys.length) detail.changedKeys = effectiveKeys;
+    if (pushToHistory !== undefined) detail.pushToHistory = pushToHistory;
+
+    dispatch('update', detail);
   }
 
   // Drag start
@@ -51,7 +57,6 @@
     position.y = clientY - offset.y;
 
     if (e.cancelable) e.preventDefault();
-    sendUpdate();
   }
 
   // Drag end
@@ -61,6 +66,7 @@
     window.removeEventListener('mouseup', onMouseUp);
     window.removeEventListener('touchmove', onMouseMove);
     window.removeEventListener('touchend', onMouseUp);
+    sendUpdate(['position']);
   }
 
   // Resize start
@@ -99,7 +105,6 @@
     size.height = Math.max(50, resizeStart.height + deltaY);
 
     if (e.cancelable) e.preventDefault();
-    sendUpdate();
   }
 
   // Resize end
@@ -110,6 +115,7 @@
     window.removeEventListener('mouseup', onResizeEnd);
     window.removeEventListener('touchmove', onResizing);
     window.removeEventListener('touchend', onResizeEnd);
+    sendUpdate(['size']);
   }
 
   // Delete block
@@ -206,10 +212,10 @@
     <div>text</div>
     <div class="header-controls" on:mousedown|stopPropagation>
       <label title="Background Color">
-        <input type="color" bind:value={bgColor} on:change={sendUpdate}/>
+        <input type="color" bind:value={bgColor} on:change={() => sendUpdate(['bgColor'])}/>
       </label>
       <label title="Text Color">
-        <input type="color" bind:value={textColor} on:change={sendUpdate}/>
+        <input type="color" bind:value={textColor} on:change={() => sendUpdate(['textColor'])}/>
       </label>
       <button class="delete-btn" on:click={deleteBlock}>×</button>
     </div>
@@ -219,7 +225,7 @@
     <textarea
       spellcheck="false"
       bind:value={content}
-      on:input={() => sendUpdate({ pushToHistory: false })}
+      on:input={() => sendUpdate(['content'], { pushToHistory: false })}
     ></textarea>
   </div>
 

--- a/src/components/TexteClean.svelte
+++ b/src/components/TexteClean.svelte
@@ -26,9 +26,16 @@
     if (editableDiv) editableDiv.innerText = content;
   });
 
-  function sendUpdate({ pushToHistory = true } = {}) {
-    content = editableDiv.innerText;
-    dispatch('update', { id, position, size, bgColor, textColor, content, pushToHistory });
+  function sendUpdate(changedKeys, { pushToHistory } = {}) {
+    content = editableDiv?.innerText ?? content;
+
+    const effectiveKeys = Array.isArray(changedKeys) && changedKeys.length ? changedKeys : [];
+    const detail = { id, position, size, bgColor, textColor, content };
+
+    if (effectiveKeys.length) detail.changedKeys = effectiveKeys;
+    if (pushToHistory !== undefined) detail.pushToHistory = pushToHistory;
+
+    dispatch('update', detail);
   }
 
   // Drag start
@@ -67,7 +74,7 @@
     window.removeEventListener('mouseup', onMouseUp);
     window.removeEventListener('touchmove', onMouseMove);
     window.removeEventListener('touchend', onMouseUp);
-    sendUpdate();
+    sendUpdate(['position']);
   }
 
   // Resize start
@@ -108,7 +115,7 @@
     window.removeEventListener('mouseup', onResizeEnd);
     window.removeEventListener('touchmove', onResizing);
     window.removeEventListener('touchend', onResizeEnd);
-    sendUpdate();
+    sendUpdate(['size']);
   }
 
   // Delete
@@ -215,8 +222,8 @@
       <button on:click={() => showSettings = !showSettings} class="gear-btn" aria-label="Settings">
         ⚙︎
       </button>
-      <input type="color" bind:value={bgColor} title="BG" on:change={sendUpdate} />
-      <input type="color" bind:value={textColor} title="Text" on:change={sendUpdate} />
+      <input type="color" bind:value={bgColor} title="BG" on:change={() => sendUpdate(['bgColor'])} />
+      <input type="color" bind:value={textColor} title="Text" on:change={() => sendUpdate(['textColor'])} />
       <button class="delete-btn" on:click={deleteBlock}>×</button>
     </div>
   </div>
@@ -226,7 +233,7 @@
     bind:this={editableDiv}
     class="editable"
     spellcheck="false"
-    on:input={() => sendUpdate({ pushToHistory: false })}
+    on:input={() => sendUpdate(['content'], { pushToHistory: false })}
   ></div>
 
   <div


### PR DESCRIPTION
## Summary
- add per-block default history triggers and expose a helper so blocks can control when snapshots are created
- pass `changedKeys` metadata from block components and simple note mode so App.svelte can skip snapshots for text edits while still autosaving
- ensure loaded/imported blocks carry history trigger settings and keep autosave snapshots aligned during undo/redo

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0108177ac832ea694ca034a9e183b