### PR TITLE
Key ModeArea to block version snapshots

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -27,6 +27,7 @@
 
   let mode = "default";
   let blocks = [];
+  $: blocksKey = blocks.map(b => `${b.id}:${b._version ?? 0}`).join('|');
   let currentSaveName = "default";
   let savedList = [];
   let fileInputRef;
@@ -80,7 +81,7 @@
         position: { ...b.position },
         size: { ...b.size }
       }));
-      blocks = snapshotBlocks;
+      blocks = [...snapshotBlocks];
       await persistAutosave(snapshotBlocks);
     }
   }
@@ -94,7 +95,7 @@
         position: { ...b.position },
         size: { ...b.size }
       }));
-      blocks = snapshotBlocks;
+      blocks = [...snapshotBlocks];
       await persistAutosave(snapshotBlocks);
     }
   }
@@ -371,14 +372,16 @@
   </div>
 
   <div class="modes">
-  <ModeArea
-    {mode}
-    {blocks}
-    {groupedBlocks}
-    bind:canvasRef
-    on:update={updateBlockHandler}
-    on:delete={deleteBlockHandler}
-  />
+    {#key blocksKey}
+      <ModeArea
+        {mode}
+        {blocks}
+        {groupedBlocks}
+        bind:canvasRef
+        on:update={updateBlockHandler}
+        on:delete={deleteBlockHandler}
+      />
+    {/key}
   </div>
 </div>
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -27,7 +27,10 @@
 
   let mode = "default";
   let blocks = [];
-  $: blocksKey = blocks.map(b => `${b.id}:${b._version ?? 0}`).join('|');
+  let blocksRenderNonce = 0;
+  $: blocksKey = `${blocksRenderNonce}:${blocks
+    .map(b => `${b.id}:${b._version ?? 0}`)
+    .join('|')}`;
   let currentSaveName = "default";
   let savedList = [];
   let fileInputRef;
@@ -56,6 +59,7 @@
 
     if (historyIndex >= 0 && history[historyIndex] === snapshot) {
       blocks = blocksWithVersion;
+      blocksRenderNonce += 1;
       await persistAutosave(blocksWithVersion);
       return;
     }
@@ -68,6 +72,7 @@
     historyIndex++;
 
     blocks = blocksWithVersion;
+    blocksRenderNonce += 1;
 
     await persistAutosave(blocksWithVersion);
   }
@@ -82,6 +87,7 @@
         size: { ...b.size }
       }));
       blocks = [...snapshotBlocks];
+      blocksRenderNonce += 1;
       await persistAutosave(snapshotBlocks);
     }
   }
@@ -96,6 +102,7 @@
         size: { ...b.size }
       }));
       blocks = [...snapshotBlocks];
+      blocksRenderNonce += 1;
       await persistAutosave(snapshotBlocks);
     }
   }


### PR DESCRIPTION
## Summary
- derive a reactive key from block ids and versions
- wrap ModeArea in a keyed block so snapshot restores remount child components
- copy undo/redo snapshots into a new array to keep reactivity nudged

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e04e83c9c0832eac838d1b351b76b1