### PR TITLE
Capture unsaved canvas state before undo

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -39,6 +39,7 @@
   // --- Undo/Redo history ---
   let history = [];
   let historyIndex = -1;
+  let hasUnsnapshottedChanges = false;
 
   function cloneBlocksForHistory(blockList, { bumpVersion = true } = {}) {
     return blockList.map(b => ({
@@ -57,6 +58,8 @@
   async function ensureCurrentHistorySnapshot() {
     if (!blocks.length && history.length) return;
 
+    if (!hasUnsnapshottedChanges) return;
+
     if (!history.length) {
       await pushHistory(blocks);
       return;
@@ -70,6 +73,8 @@
 
     if (latestHistorySnapshot !== currentSnapshot) {
       await pushHistory(blocks);
+    } else {
+      hasUnsnapshottedChanges = false;
     }
   }
 
@@ -88,6 +93,7 @@
       blocks = blocksWithVersion;
       blocksRenderNonce += 1;
       await persistAutosave(blocksWithVersion);
+      hasUnsnapshottedChanges = false;
       return;
     }
 
@@ -102,6 +108,7 @@
     blocksRenderNonce += 1;
 
     await persistAutosave(blocksWithVersion);
+    hasUnsnapshottedChanges = false;
   }
 
   async function undo() {
@@ -213,6 +220,7 @@
     } else {
       blocks = [...newBlocks];
       await persistAutosave(blocks);
+      hasUnsnapshottedChanges = true;
     }
   }
 


### PR DESCRIPTION
## Summary
- add reusable helpers to clone and serialize blocks for history snapshots
- ensure the current state is recorded before performing the first undo so redo can restore recent edits

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0f86ede78832e95c697007ac79ef1