### PR TITLE
Refactor editor state utilities into reusable modules

### DIFF
--- a/src/utils/browserStorage.js
+++ b/src/utils/browserStorage.js
@@ -1,0 +1,70 @@
+const isStorageAvailable = storage => {
+  if (!storage) return false;
+  try {
+    const testKey = '__storage_test__';
+    storage.setItem(testKey, 'test');
+    storage.removeItem(testKey);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+export function getLocalStorage() {
+  if (typeof window === 'undefined' || !('localStorage' in window)) {
+    return null;
+  }
+  const storage = window.localStorage;
+  return isStorageAvailable(storage) ? storage : null;
+}
+
+export function readJSON(key, fallback = null, storage = getLocalStorage()) {
+  if (!storage) return fallback;
+  try {
+    const raw = storage.getItem(key);
+    if (raw == null) return fallback;
+    return JSON.parse(raw);
+  } catch {
+    return fallback;
+  }
+}
+
+export function writeJSON(key, value, storage = getLocalStorage()) {
+  if (!storage) return false;
+  try {
+    storage.setItem(key, JSON.stringify(value));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function readValue(key, fallback = null, storage = getLocalStorage()) {
+  if (!storage) return fallback;
+  try {
+    const value = storage.getItem(key);
+    return value == null ? fallback : value;
+  } catch {
+    return fallback;
+  }
+}
+
+export function writeValue(key, value, storage = getLocalStorage()) {
+  if (!storage) return false;
+  try {
+    storage.setItem(key, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function removeValue(key, storage = getLocalStorage()) {
+  if (!storage) return false;
+  try {
+    storage.removeItem(key);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/utils/historyTriggers.js
+++ b/src/utils/historyTriggers.js
@@ -1,0 +1,33 @@
+export const DEFAULT_HISTORY_TRIGGERS = {
+  text: ['position', 'size', 'bgColor', 'textColor'],
+  cleantext: ['position', 'size', 'bgColor', 'textColor'],
+  image: ['position', 'size', 'bgColor', 'textColor', 'src'],
+  music: [
+    'position',
+    'size',
+    'bgColor',
+    'textColor',
+    'trackUrl',
+    'title',
+    'content'
+  ],
+  embed: ['position', 'size', 'bgColor', 'textColor', 'content'],
+  __default: [
+    'position',
+    'size',
+    'bgColor',
+    'textColor',
+    'content',
+    'src',
+    'trackUrl',
+    'title'
+  ]
+};
+
+export function applyHistoryTriggers(block) {
+  const triggers =
+    block.historyTriggers ??
+    DEFAULT_HISTORY_TRIGGERS[block.type] ??
+    DEFAULT_HISTORY_TRIGGERS.__default;
+  return { ...block, historyTriggers: triggers };
+}

--- a/src/utils/modeOrders.js
+++ b/src/utils/modeOrders.js
@@ -1,0 +1,29 @@
+export const KNOWN_MODES = ['default', 'simple'];
+
+export function ensureModeOrders(allBlocks, incomingOrders = {}) {
+  const idsInBlockOrder = allBlocks.map(block => block.id);
+  const validIds = new Set(idsInBlockOrder);
+  const modeNames = new Set([
+    ...KNOWN_MODES,
+    ...Object.keys(incomingOrders || {})
+  ]);
+
+  const normalized = {};
+  for (const name of modeNames) {
+    const existing = Array.isArray(incomingOrders?.[name])
+      ? incomingOrders[name].filter(id => validIds.has(id))
+      : [];
+    const missing = idsInBlockOrder.filter(id => !existing.includes(id));
+    normalized[name] = [...existing, ...missing];
+  }
+
+  return normalized;
+}
+
+export function cloneModeOrders(orders = {}) {
+  const clone = {};
+  for (const [modeName, order] of Object.entries(orders || {})) {
+    clone[modeName] = Array.isArray(order) ? [...order] : [];
+  }
+  return clone;
+}

--- a/src/utils/preferences.js
+++ b/src/utils/preferences.js
@@ -1,0 +1,71 @@
+import { readJSON, writeJSON, readValue, writeValue, removeValue } from './browserStorage';
+
+export const CONTROL_COLOR_STORAGE_KEY = 'controlColors';
+export const LAST_SAVE_STORAGE_KEY = 'lastLoadedSave';
+
+export const CONTROL_COLOR_DEFAULTS = {
+  left: {
+    panelBg: '#111111b0',
+    textColor: '#ffffff',
+    buttonBg: '#333333',
+    buttonText: '#ffffff',
+    borderColor: '#444444',
+    inputBg: '#1d1d1d'
+  },
+  right: {
+    panelBg: '#222222',
+    textColor: '#ffffff',
+    buttonBg: '#222222',
+    buttonText: '#ffffff',
+    borderColor: '#444444'
+  },
+  canvas: {
+    outerBg: '#000000',
+    innerBg: '#000000'
+  }
+};
+
+export function normalizeControlColors(raw = {}) {
+  const left = {
+    ...CONTROL_COLOR_DEFAULTS.left,
+    ...(raw.left || {})
+  };
+
+  if (!('inputBg' in left) || !left.inputBg) {
+    left.inputBg = (raw.left && raw.left.panelBg) || CONTROL_COLOR_DEFAULTS.left.inputBg;
+  }
+
+  const right = {
+    ...CONTROL_COLOR_DEFAULTS.right,
+    ...(raw.right || {})
+  };
+
+  const canvas = {
+    ...CONTROL_COLOR_DEFAULTS.canvas,
+    ...(raw.canvas || {})
+  };
+
+  return { left, right, canvas };
+}
+
+export function loadStoredControlColors() {
+  const stored = readJSON(CONTROL_COLOR_STORAGE_KEY);
+  return stored ? normalizeControlColors(stored) : null;
+}
+
+export function persistControlColors(colors) {
+  const normalized = normalizeControlColors(colors);
+  writeJSON(CONTROL_COLOR_STORAGE_KEY, normalized);
+}
+
+export function loadStoredLastSaveName() {
+  return readValue(LAST_SAVE_STORAGE_KEY);
+}
+
+export function persistLastSaveName(name) {
+  if (!name) {
+    removeValue(LAST_SAVE_STORAGE_KEY);
+    return;
+  }
+  writeValue(LAST_SAVE_STORAGE_KEY, name);
+}

--- a/src/utils/stateSnapshots.js
+++ b/src/utils/stateSnapshots.js
@@ -1,0 +1,21 @@
+import { ensureModeOrders, cloneModeOrders } from './modeOrders';
+
+export function cloneState(blockList, orders, { bumpVersion = true } = {}) {
+  const normalizedOrders = ensureModeOrders(blockList, orders);
+  const blocksClone = blockList.map(block => ({
+    ...block,
+    _version: bumpVersion ? (block._version || 0) + 1 : block._version ?? 0,
+    position: { ...block.position },
+    size: { ...block.size }
+  }));
+
+  return {
+    blocks: blocksClone,
+    modeOrders: cloneModeOrders(normalizedOrders)
+  };
+}
+
+export function serializeState(blockList, orders, { bumpVersion = false } = {}) {
+  const snapshot = cloneState(blockList, orders, { bumpVersion });
+  return JSON.stringify(snapshot);
+}


### PR DESCRIPTION
## Summary
- extract control color persistence into a dedicated preferences utility backed by safe localStorage helpers
- move mode-ordering, history trigger, and snapshot helpers into focused modules to simplify `App.svelte`
- harden window-dependent logic for responsive layout handling during initialization

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690bb5d69124832ea605c0b037a28445