### PR TITLE
Restore SimpleNote layout and controls

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -499,23 +499,16 @@
   }
 
   async function deleteSave(name) {
-    const deletingCurrent = currentSaveName === name;
     await deleteBlocks(name);
-
-    if (deletingCurrent) {
-      blocks = [];
-      currentSaveName = "";
-      persistLastSaveName("");
-    }
-
+    if (currentSaveName === name) blocks = [];
     modeOrders = ensureModeOrders(blocks, modeOrders);
     if (focusedBlockId && !blocks.some(b => b.id === focusedBlockId)) {
       focusedBlockId = null;
     }
     savedList = await listSavedBlocks();
 
-    if (!deletingCurrent && loadStoredLastSaveName() === name) {
-      persistLastSaveName(currentSaveName);
+    if (loadStoredLastSaveName() === name) {
+      persistLastSaveName(currentSaveName === name ? "" : currentSaveName);
     }
 
     history = [];


### PR DESCRIPTION
## Summary
- revert the app state management to the previous SimpleNote configuration without theme preset handling
- collapse the right side controls back into the original vertically scrolling parameters panel
- update each block component to rely on their inline variables again and drop shared CSS theme dependencies

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690bb91a6304832ebf44a526e4fbff79