### PR TITLE
Allow copying within advanced CSS builder

### DIFF
--- a/src/advanced-param/AdvancedCssPage.svelte
+++ b/src/advanced-param/AdvancedCssPage.svelte
@@ -461,6 +461,11 @@
     align-items: center;
     padding: clamp(12px, 3vh, 36px) clamp(16px, 4vw, 48px);
     z-index: 1200;
+    user-select: text;
+  }
+
+  .overlay * {
+    user-select: text;
   }
 
   .panel {


### PR DESCRIPTION
## Summary
- allow selecting text across the Advanced CSS builder overlay so clipboard shortcuts work reliably

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690bf2bf6b58832eb2de11c03ceb9b85