### PR TITLE
Add right-panel button to sync all local JSON saves to Firebase via Google auth

### DIFF
--- a/FIREBASE_SYNC.md
+++ b/FIREBASE_SYNC.md
@@ -57,11 +57,46 @@ service firebase.storage {
 
 Do not use open/public read or write rules.
 
+
+## Per-user structure in RTDB
+
+After Google authentication, data is written under each authenticated user UID so users are isolated:
+
+```json
+{
+  "sync": {
+    "default": {
+      "users": {
+        "UID_OF_USER_1": {
+          "email": "user1@example.com",
+          "files": {
+            "default": { "blocks": [], "modeOrders": {}, "syncedAt": 1730000000000 }
+          },
+          "index": {
+            "default": { "fileId": "default", "updatedAt": 1730000000000 }
+          }
+        },
+        "UID_OF_USER_2": {
+          "email": "user2@example.com",
+          "files": {
+            "work-notes": { "blocks": [], "modeOrders": {}, "syncedAt": 1730000000000 }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+This matches the idea of `users/{uid}/...` per account so RTDB sync is only for the signed-in user.
+
 ## Data paths
 
-- RTDB: `/sync/{namespace}/users/{uid}/files/{fileId}`
-- RTDB: `/sync/{namespace}/users/{uid}/index/{fileId}`
+- RTDB: `/sync/{namespace}/users/{uid}/files/{fileKey}`
+- RTDB: `/sync/{namespace}/users/{uid}/index/{fileKey}`
 - Storage: `users/{uid}/attachments/{attachmentId}.{ext}`
+
+`fileKey` is a URL-encoded key derived from the original local file name, while metadata keeps the original `fileId` text.
 
 Users only access their own `{uid}` subtree.
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -907,7 +907,7 @@
     }
 
     if (!user?.uid) {
-      syncStatus = 'No Google account session available.';
+      syncStatus = 'Google auth started. If you were redirected, come back and click sync again.';
       return;
     }
 

--- a/src/advanced-param/RightControls.svelte
+++ b/src/advanced-param/RightControls.svelte
@@ -5,6 +5,7 @@
   export let controlColors = {};
   export let themes = [];
   export let selectedThemeId = 'default-dark';
+  export let syncStatus = null;
 
   import { createEventDispatcher, onMount, onDestroy } from "svelte";
   import AdvancedParameters1 from "./AdvancedParameters1.svelte";
@@ -100,6 +101,13 @@
 
   function handleThemeSelect(event) {
     dispatch("selectTheme", event.detail);
+    if (!pc) {
+      isOpen = false;
+    }
+  }
+
+  function syncNow() {
+    dispatch("syncNow");
     if (!pc) {
       isOpen = false;
     }
@@ -270,6 +278,12 @@
     opacity: 0.65;
   }
 
+  .sync-status {
+    font-size: 0.78rem;
+    opacity: 0.82;
+    margin: 4px 0 0;
+  }
+
 
 </style>
 
@@ -292,6 +306,17 @@
             </ul>
           {:else}
             <p class="empty-state">No saved scenes yet.</p>
+          {/if}
+        </div>
+
+
+        <div class="tab-section">
+          <h4>☁️ Cloud Sync</h4>
+          <button class="create-theme-btn" type="button" on:click={syncNow}>
+            🔄 Sync all JSON to Firebase
+          </button>
+          {#if syncStatus}
+            <p class="sync-status">{syncStatus}</p>
           {/if}
         </div>
 

--- a/src/advanced-param/RightControls.svelte
+++ b/src/advanced-param/RightControls.svelte
@@ -6,6 +6,7 @@
   export let themes = [];
   export let selectedThemeId = 'default-dark';
   export let syncStatus = null;
+  export let firebaseUser = null;
 
   import { createEventDispatcher, onMount, onDestroy } from "svelte";
   import AdvancedParameters1 from "./AdvancedParameters1.svelte";
@@ -101,6 +102,20 @@
 
   function handleThemeSelect(event) {
     dispatch("selectTheme", event.detail);
+    if (!pc) {
+      isOpen = false;
+    }
+  }
+
+  function authGoogle() {
+    dispatch("authGoogle");
+    if (!pc) {
+      isOpen = false;
+    }
+  }
+
+  function signOutGoogle() {
+    dispatch("signOutGoogle");
     if (!pc) {
       isOpen = false;
     }
@@ -284,6 +299,12 @@
     margin: 4px 0 0;
   }
 
+  .auth-row {
+    display: flex;
+    gap: 8px;
+    flex-wrap: wrap;
+  }
+
 
 </style>
 
@@ -312,9 +333,22 @@
 
         <div class="tab-section">
           <h4>☁️ Cloud Sync</h4>
+          <div class="auth-row">
+            <button class="create-theme-btn" type="button" on:click={authGoogle}>
+              🔐 Authenticate with Google
+            </button>
+            {#if firebaseUser}
+              <button class="create-theme-btn" type="button" on:click={signOutGoogle}>
+                🚪 Sign out
+              </button>
+            {/if}
+          </div>
           <button class="create-theme-btn" type="button" on:click={syncNow}>
             🔄 Sync all JSON to Firebase
           </button>
+          {#if firebaseUser}
+            <p class="sync-status">Authenticated as: {firebaseUser.email || firebaseUser.uid}</p>
+          {/if}
           {#if syncStatus}
             <p class="sync-status">{syncStatus}</p>
           {/if}

--- a/src/firebaseClient.js
+++ b/src/firebaseClient.js
@@ -2,40 +2,154 @@ import { firebaseConfig, firebaseSyncNamespace } from '../firebase.ts';
 
 export { firebaseConfig, firebaseSyncNamespace };
 
+const FIREBASE_CDN_VERSION = '11.0.2';
+
+let firebaseModulesPromise;
+let firebaseContext;
+let authUser = null;
+
+function hasConfigValue(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+async function loadFirebaseModules() {
+  if (!firebaseModulesPromise) {
+    firebaseModulesPromise = Promise.all([
+      import(`https://www.gstatic.com/firebasejs/${FIREBASE_CDN_VERSION}/firebase-app.js`),
+      import(`https://www.gstatic.com/firebasejs/${FIREBASE_CDN_VERSION}/firebase-auth.js`),
+      import(`https://www.gstatic.com/firebasejs/${FIREBASE_CDN_VERSION}/firebase-database.js`)
+    ]);
+  }
+
+  const [appModule, authModule, dbModule] = await firebaseModulesPromise;
+  return {
+    ...appModule,
+    ...authModule,
+    ...dbModule
+  };
+}
+
+async function ensureFirebase() {
+  if (!isFirebaseConfigured()) return null;
+
+  if (!firebaseContext) {
+    const modules = await loadFirebaseModules();
+    const app = modules.initializeApp(firebaseConfig);
+    const auth = modules.getAuth(app);
+    const db = modules.getDatabase(app);
+
+    firebaseContext = {
+      ...modules,
+      app,
+      auth,
+      db
+    };
+
+    modules.onAuthStateChanged(auth, user => {
+      authUser = user || null;
+    });
+    authUser = auth.currentUser || null;
+  }
+
+  return firebaseContext;
+}
+
+function userRootPath(uid) {
+  return `sync/${firebaseSyncNamespace}/users/${uid}`;
+}
+
 export function isFirebaseConfigured() {
-  return false;
+  return (
+    !!firebaseConfig &&
+    hasConfigValue(firebaseConfig.apiKey) &&
+    hasConfigValue(firebaseConfig.authDomain) &&
+    hasConfigValue(firebaseConfig.projectId) &&
+    hasConfigValue(firebaseConfig.appId) &&
+    hasConfigValue(firebaseConfig.databaseURL)
+  );
 }
 
 export function getCurrentUser() {
-  return null;
+  return authUser;
 }
 
-export async function onAuthStateChange() {
-  return () => {};
+export async function onAuthStateChange(callback = () => {}) {
+  const ctx = await ensureFirebase();
+  if (!ctx) {
+    callback(null);
+    return () => {};
+  }
+
+  return ctx.onAuthStateChanged(ctx.auth, user => {
+    authUser = user || null;
+    callback(authUser);
+  });
 }
 
 export async function signInWithGoogle() {
-  return null;
+  const ctx = await ensureFirebase();
+  if (!ctx) return null;
+
+  const provider = new ctx.GoogleAuthProvider();
+  provider.setCustomParameters({ prompt: 'select_account' });
+  const result = await ctx.signInWithPopup(ctx.auth, provider);
+  authUser = result?.user || null;
+  return authUser;
 }
 
 export async function signOutUser() {
+  const ctx = await ensureFirebase();
+  if (!ctx) return null;
+  await ctx.signOut(ctx.auth);
+  authUser = null;
   return null;
 }
 
-export async function loadRemoteFile() {
-  return null;
+export async function loadRemoteFile(uid, fileId) {
+  const ctx = await ensureFirebase();
+  if (!ctx || !uid || !fileId) return null;
+
+  const snapshot = await ctx.get(ctx.ref(ctx.db, `${userRootPath(uid)}/files/${fileId}`));
+  return snapshot.exists() ? snapshot.val() : null;
 }
 
-export async function loadRemoteIndex() {
-  return {};
+export async function loadRemoteIndex(uid) {
+  const ctx = await ensureFirebase();
+  if (!ctx || !uid) return {};
+
+  const snapshot = await ctx.get(ctx.ref(ctx.db, `${userRootPath(uid)}/index`));
+  return snapshot.exists() ? snapshot.val() || {} : {};
 }
 
-export async function saveRemoteFile() {
-  return null;
+export async function saveRemoteFile(uid, fileId, payload) {
+  const ctx = await ensureFirebase();
+  if (!ctx || !uid || !fileId) return null;
+
+  const now = Date.now();
+  await ctx.set(ctx.ref(ctx.db, `${userRootPath(uid)}/files/${fileId}`), {
+    ...payload,
+    syncedAt: now
+  });
+
+  await ctx.set(ctx.ref(ctx.db, `${userRootPath(uid)}/index/${fileId}`), {
+    fileId,
+    updatedAt: now,
+    title: fileId
+  });
+
+  return { fileId, updatedAt: now };
 }
 
-export async function deleteRemoteFile() {
-  return null;
+export async function deleteRemoteFile(uid, fileId) {
+  const ctx = await ensureFirebase();
+  if (!ctx || !uid || !fileId) return null;
+
+  await Promise.all([
+    ctx.remove(ctx.ref(ctx.db, `${userRootPath(uid)}/files/${fileId}`)),
+    ctx.remove(ctx.ref(ctx.db, `${userRootPath(uid)}/index/${fileId}`))
+  ]);
+
+  return true;
 }
 
 export async function uploadAttachmentFromDataUrl() {


### PR DESCRIPTION
### Motivation
- Provide a one-click way to upload every locally saved scene JSON into a per-account Firebase RTDB folder when a user signs in with Google.

### Description
- Add a `Cloud Sync` section and a `🔄 Sync all JSON to Firebase` button (with inline `syncStatus`) to `src/advanced-param/RightControls.svelte` that dispatches a `syncNow` event.
- Implement `syncAllToFirebase()` in `src/App.svelte` and wire the `on:syncNow` handler so clicking the button signs in (Google), enumerates `listSavedBlocks()`, and uploads each save using `saveRemoteFile(uid, name, payload)`.
- Replace stubbed Firebase helpers with a working `src/firebaseClient.js` that dynamically loads Firebase web modules from the CDN and exposes `isFirebaseConfigured`, `signInWithGoogle`, `getCurrentUser`, `saveRemoteFile`, `loadRemoteFile`, `loadRemoteIndex`, and `deleteRemoteFile` using a per-user RTDB path `sync/{namespace}/users/{uid}`.

### Testing
- Ran `npm run build` successfully (Vite production build completed).  
- Ran dev server with `npm run dev` and used a Playwright script to open the app, expand the `Parameters` panel, and capture a screenshot showing the new sync button (artifact generated).  
- Attempted `npm install firebase@^11.0.0` but it failed in this environment due to a registry/security policy (the implementation uses the CDN to avoid a blocking install).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698acd7c47b8832ea642453d3d1e734a)