### PR TITLE
Convert Birthday Mode into PC Piano Tiles (D/F/J/K)

### DIFF
--- a/src/modes/BirthdayMode.svelte
+++ b/src/modes/BirthdayMode.svelte
@@ -49,7 +49,7 @@
   const noteSpeed = 260;
   const noteHeight = 84;
   const hitLineOffset = 120;
-  const hitWindow = 56;
+  const hitWindow = noteHeight;
 
   let notes = [];
   let active = false;


### PR DESCRIPTION
### Motivation
- Provide a desktop-friendly Piano Tiles experience that maps four lanes to `D`, `F`, `J`, and `K`, with an easy note pattern and a strict perfect-run win condition.

### Description
- Replaced the previous beat/melody-based implementation with a tile spawner and falling-note system in `src/modes/BirthdayMode.svelte` using an `easyPattern` sequence.  
- Added keyboard handlers (`handleKeyDown` / `handleKeyUp`) and a `keyToLane` map so `KeyD`, `KeyF`, `KeyJ`, and `KeyK` trigger lane hits and visual key feedback.  
- Implemented core gameplay functions: `startGame`, `addNote`, `tick` (animation loop), `nearestNoteInLane`, `fail`, and `checkWin`, and replaced the old audio logic with a lightweight `playBeep` per lane.  
- Added UI/UX updates: 4-lane layout, hit-line, HUD with `Start`/`Restart`/`Try Again`, a win screen with animated confetti, and adjusted styling to match the piano-tiles look.

### Testing
- Ran `npm run build` which completed successfully (`vite build` produced `dist` bundles`).  
- Attempted an automated Playwright run to load the dev server and capture a screenshot, but Chromium crashed with `SIGSEGV` in this environment so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b9beb1980832e96fd66b081f79340)