### PR TITLE
Move mobile Mode and Add Block controls out of slide-out menu

### DIFF
--- a/src/advanced-param/LeftControls.svelte
+++ b/src/advanced-param/LeftControls.svelte
@@ -20,6 +20,7 @@
   let modeButtonRef;
   let addBlockMenuRef;
   let addBlockButtonRef;
+  let mobileQuickActionsRef;
   let showModeLadder = false;
   let showAddBlockMenu = false;
   let birthdayPassword = '';
@@ -133,7 +134,8 @@
     if (
       showMobileMenu &&
       !menuRef.contains(event.target) &&
-      !toggleRef.contains(event.target)
+      !toggleRef.contains(event.target) &&
+      !mobileQuickActionsRef?.contains(event.target)
     ) {
       showMobileMenu = false;
     }
@@ -305,6 +307,16 @@ onMount(() => {
     transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
   }
 
+  .mobile-quick-actions {
+    display: none;
+    position: fixed;
+    top: 29px;
+    left: 130px;
+    z-index: 1000;
+    align-items: center;
+    gap: 8px;
+  }
+
   @media (max-width: 1024px) {
     .left-controls {
       display: none;
@@ -330,6 +342,14 @@ onMount(() => {
       left: 10px;
       z-index: 1000;
     }
+
+    .mobile-quick-actions {
+      display: inline-flex;
+    }
+
+    .mobile-only {
+      display: none;
+    }
   }
 </style>
 
@@ -343,6 +363,69 @@ onMount(() => {
     >
       {showMobileMenu ? "✖ Close" : "☰ Menu"}
     </button>
+
+    <div class="mobile-quick-actions" bind:this={mobileQuickActionsRef}>
+      <div class="mode-switcher">
+        <button
+          bind:this={modeButtonRef}
+          on:click={toggleModeMenu}
+          aria-haspopup="listbox"
+          aria-expanded={showModeLadder}
+        >
+          📝 {modeLabels?.[mode] ?? mode}
+        </button>
+        {#if showModeLadder}
+          <div class="mode-ladder" bind:this={modeMenuRef} role="listbox">
+            {#each modeOptions as option}
+              <button
+                class:active={option.id === mode}
+                on:click={() => selectMode(option.id)}
+                role="option"
+                aria-selected={option.id === mode}
+                disabled={option.id === 'birthday' && !birthdayModeUnlocked}
+              >
+                {option.label}
+              </button>
+            {/each}
+            {#if !birthdayModeUnlocked}
+              <div class="birthday-unlock">
+                <small>Unlock birthday mode for 24 hours.</small>
+                <div class="birthday-unlock-row">
+                  <input type="password" bind:value={birthdayPassword} placeholder="Password" />
+                  <button on:click={unlockBirthdayMode}>Unlock</button>
+                </div>
+                {#if birthdayUnlockMessage}
+                  <small>{birthdayUnlockMessage}</small>
+                {/if}
+              </div>
+            {/if}
+          </div>
+        {/if}
+      </div>
+
+      <div class="add-block-menu">
+        <button
+          bind:this={addBlockButtonRef}
+          on:click={toggleAddBlockMenu}
+          aria-haspopup="listbox"
+          aria-expanded={showAddBlockMenu}
+        >
+          ➕ Add block
+        </button>
+        {#if showAddBlockMenu}
+          <div class="add-block-list" bind:this={addBlockMenuRef} role="listbox">
+            <button on:click={() => addBlock("text")}>+ Text</button>
+            <button on:click={() => addBlock("cleantext")}>+ Clean Text</button>
+            <button on:click={() => addBlock("image")} disabled={isSingleNoteMode}>+ Image</button>
+            <button on:click={() => addBlock("music")} disabled={isSingleNoteMode}>+ Music</button>
+            <button on:click={() => addBlock("embed")} disabled={isSingleNoteMode}>+ Embed</button>
+            {#if isTaskMode}
+              <button on:click={() => addBlock("task")}>+ Task List</button>
+            {/if}
+          </div>
+        {/if}
+      </div>
+    </div>
   {/if}
 
   <!-- Controls -->
@@ -350,7 +433,7 @@ onMount(() => {
     class="left-controls {showMobileMenu ? 'show' : ''}"
     bind:this={menuRef}
   >
-    <div class="mode-switcher">
+    <div class="mode-switcher mobile-only">
       <button
         bind:this={modeButtonRef}
         on:click={toggleModeMenu}
@@ -387,7 +470,7 @@ onMount(() => {
         </div>
       {/if}
     </div>
-    <div class="add-block-menu">
+    <div class="add-block-menu mobile-only">
       <button
         bind:this={addBlockButtonRef}
         on:click={toggleAddBlockMenu}


### PR DESCRIPTION
### Motivation
- Improve mobile UX by making the Mode selector and Add Block action accessible without opening the slide-out menu. 
- Prevent the mobile menu from closing when interacting with these frequently-used controls.

### Description
- Added a dedicated `.mobile-quick-actions` row that shows on small viewports and contains the Mode and ➕ Add block buttons so they sit next to the hamburger toggle. (`src/advanced-param/LeftControls.svelte`)
- Introduced `mobileQuickActionsRef` and updated `handleClickOutside` so clicks on the quick-action area are treated as inside the UI and do not collapse the mobile menu. (`handleClickOutside` changes)
- Kept existing dropdown/menu logic and duplicated controls inside the slide-out panel for desktop, but hide the in-menu duplicates on mobile via the `.mobile-only` class and responsive CSS. (CSS additions / media query changes)

### Testing
- Ran build with `npm run build` which completed successfully. 
- Launched dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified mobile layout manually. 
- Automated browser check captured a mobile viewport screenshot showing the quick actions outside the menu (artifact: `artifacts/mobile-quick-actions.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699beb5d3cb4832ebb964ed9e20fc9aa)