### PR TITLE
Default mobile viewport to Simple Note mode

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -30,6 +30,12 @@
   const BIRTHDAY_UNLOCK_STORAGE_KEY = 'birthdayModeAccess';
   const BIRTHDAY_MODE_PASSWORD = 'Birthday24H';
   const BIRTHDAY_MODE_DURATION_MS = 24 * 60 * 60 * 1000;
+  const MOBILE_BREAKPOINT = 1024;
+
+  function getDefaultModeForViewport() {
+    if (typeof window === 'undefined') return 'default';
+    return window.innerWidth <= MOBILE_BREAKPOINT ? 'simple' : 'default';
+  }
 
   function toCssVarName(key) {
     return key
@@ -744,7 +750,7 @@
   let controlsResizeObserver;
   let observedControlsEl;
 
-  let mode = "default";
+  let mode = getDefaultModeForViewport();
   let blocks = [];
   let modeOrders = {};
   let normalizedModeOrders = ensureModeOrders(blocks, modeOrders);
@@ -784,7 +790,7 @@
   $: leftTheme = controlColors.left || CONTROL_COLOR_DEFAULTS.left;
   $: controlsStyle = `--controls-bg: ${leftTheme.panelBg}; --controls-border: ${leftTheme.borderColor};`;
   $: canvasTheme = controlColors.canvas || CONTROL_COLOR_DEFAULTS.canvas;
-  let Pc = window.innerWidth > 1024;
+  let Pc = window.innerWidth > MOBILE_BREAKPOINT;
   let birthdayUnlockExpiry = loadBirthdayUnlockExpiry();
   let birthdayUnlockMessage = "";
   let deferredLastSaveName = '';
@@ -1277,7 +1283,7 @@
   function adjustCanvasPadding() {
     if (typeof window === "undefined") return;
 
-    if (window.innerWidth <= 1024) {
+    if (window.innerWidth <= MOBILE_BREAKPOINT) {
       setControlsHeight(75);
       return;
     }
@@ -1303,7 +1309,7 @@
 
   const handleWindowResize = () => {
     adjustCanvasPadding();
-    Pc = window.innerWidth > 1024;
+    Pc = window.innerWidth > MOBILE_BREAKPOINT;
   };
 
   function handleFocusToggle(event) {
@@ -1358,7 +1364,7 @@
   }
 
   $: if (!birthdayModeUnlocked && mode === "birthday") {
-    mode = "default";
+    mode = getDefaultModeForViewport();
   }
 
   function setMode(nextMode) {
@@ -1385,7 +1391,7 @@
   let stopAuthListener = () => {};
 
   onMount(async () => {
-    Pc = window.innerWidth > 1024;
+    Pc = window.innerWidth > MOBILE_BREAKPOINT;
     window.addEventListener("resize", handleWindowResize);
     window.addEventListener("keydown", handleUndoRedoShortcut);
     adjustCanvasPadding();
@@ -1458,7 +1464,7 @@
     if (birthdayUnlockExpiry <= Date.now()) {
       birthdayUnlockExpiry = 0;
       persistBirthdayUnlockExpiry(0);
-      if (mode === "birthday") mode = "default";
+      if (mode === "birthday") mode = getDefaultModeForViewport();
     }
 
     history = [];


### PR DESCRIPTION
### Motivation

- Ensure the app opens in `simple` (Simple Note) mode on mobile-sized viewports while keeping desktop behavior unchanged.
- Centralize the mobile breakpoint so viewport-based logic is consistent across the app.
- Make fallback behavior (e.g. after exiting `birthday` mode) respect the viewport-appropriate default instead of always using `default`.

### Description

- Added a `MOBILE_BREAKPOINT` constant and a `getDefaultModeForViewport()` helper to `src/App.svelte` to determine the appropriate default mode based on `window.innerWidth`.
- Initialized `mode` with `getDefaultModeForViewport()` so mobile viewports start in `simple` mode and desktop viewports remain `default`.
- Replaced hardcoded `1024` checks with `MOBILE_BREAKPOINT` for `Pc`, `adjustCanvasPadding()` logic, and `handleWindowResize()` to keep mobile/desktop logic consistent.
- Updated birthday-mode fallback logic to call `getDefaultModeForViewport()` rather than always reverting to `default`.

### Testing

- Ran `npm run build` and the build completed successfully.
- Launched the dev server with `npm run dev` and it started successfully for validation.
- Executed an automated Playwright check that opened the app at a mobile viewport and captured a screenshot verifying the app opens in Simple Note mode (screenshot generated successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f73d4d7fc832ea0d8734cb4c5b267)