### PR TITLE
Fix Firebase Realtime Database sync in packaged Tauri builds

### DIFF
--- a/src/firebaseClient.js
+++ b/src/firebaseClient.js
@@ -12,31 +12,65 @@ const REQUIRED_FIREBASE_KEYS = [
 
 const FIREBASE_SDK_VERSION = '11.7.0';
 
-let firebaseModulesPromise;
+const FIREBASE_COMPAT_SCRIPTS = [
+  `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-app-compat.js`,
+  `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-auth-compat.js`,
+  `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-database-compat.js`
+];
+
+let firebaseScriptsPromise;
 let firebaseContextPromise;
 
-function loadFirebaseModules() {
-  if (!firebaseModulesPromise) {
-    firebaseModulesPromise = Promise.all([
-      import(/* @vite-ignore */ `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-app.js`),
-      import(/* @vite-ignore */ `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-auth.js`),
-      import(/* @vite-ignore */ `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-database.js`)
-    ]).then(([app, auth, database]) => ({ app, auth, database }));
+function loadScript(src) {
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[data-firebase-sdk="${src}"]`);
+    if (existing) {
+      if (existing.dataset.loaded === 'true') {
+        resolve();
+      } else {
+        existing.addEventListener('load', () => resolve(), { once: true });
+        existing.addEventListener('error', () => reject(new Error(`Failed to load Firebase script: ${src}`)), { once: true });
+      }
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.dataset.firebaseSdk = src;
+    script.onload = () => {
+      script.dataset.loaded = 'true';
+      resolve();
+    };
+    script.onerror = () => reject(new Error(`Failed to load Firebase script: ${src}`));
+    document.head.appendChild(script);
+  });
+}
+
+function loadFirebaseScripts() {
+  if (!firebaseScriptsPromise) {
+    firebaseScriptsPromise = FIREBASE_COMPAT_SCRIPTS.reduce(
+      (chain, src) => chain.then(() => loadScript(src)),
+      Promise.resolve()
+    );
   }
-  return firebaseModulesPromise;
+  return firebaseScriptsPromise;
 }
 
 async function getFirebaseContext() {
   if (!isFirebaseConfigured()) return null;
   if (!firebaseContextPromise) {
-    firebaseContextPromise = loadFirebaseModules().then(({ app, auth, database }) => {
-      const firebaseApp = app.getApps().length
-        ? app.getApp()
-        : app.initializeApp(firebaseConfig);
-      const firebaseAuth = auth.getAuth(firebaseApp);
-      auth.setPersistence(firebaseAuth, auth.browserLocalPersistence).catch(() => {});
-      const firebaseDb = database.getDatabase(firebaseApp);
-      return { app: firebaseApp, auth: firebaseAuth, db: firebaseDb, authApi: auth, dbApi: database };
+    firebaseContextPromise = loadFirebaseScripts().then(() => {
+      const firebase = window?.firebase;
+      if (!firebase) {
+        throw new Error('Firebase SDK failed to initialize.');
+      }
+
+      const app = firebase.apps.length ? firebase.app() : firebase.initializeApp(firebaseConfig);
+      const auth = firebase.auth(app);
+      auth.setPersistence(firebase.auth.Auth.Persistence.LOCAL).catch(() => {});
+      const db = firebase.database(app);
+      return { app, auth, db };
     });
   }
   return firebaseContextPromise;
@@ -64,7 +98,7 @@ export function isFirebaseConfigured() {
 }
 
 export function getCurrentUser() {
-  return null;
+  return window?.firebase?.auth?.()?.currentUser ?? null;
 }
 
 export function onAuthStateChange(callback) {
@@ -77,7 +111,7 @@ export function onAuthStateChange(callback) {
         callback?.(null);
         return;
       }
-      unsub = ctx.authApi.onAuthStateChanged(ctx.auth, callback);
+      unsub = ctx.auth.onAuthStateChanged(callback);
     })
     .catch(() => {
       callback?.(null);
@@ -93,15 +127,15 @@ export async function signInWithGoogle() {
   const ctx = await getFirebaseContext();
   if (!ctx) throw new Error('Firebase is not configured.');
 
-  const provider = new ctx.authApi.GoogleAuthProvider();
-  const result = await ctx.authApi.signInWithPopup(ctx.auth, provider);
+  const provider = new window.firebase.auth.GoogleAuthProvider();
+  const result = await ctx.auth.signInWithPopup(provider);
   return result.user;
 }
 
 export async function signOutUser() {
   const ctx = await getFirebaseContext();
   if (!ctx) return;
-  await ctx.authApi.signOut(ctx.auth);
+  await ctx.auth.signOut();
 }
 
 export async function loadRemoteFile(fileId) {
@@ -109,9 +143,7 @@ export async function loadRemoteFile(fileId) {
   const ctx = await getFirebaseContext();
   const user = requireUser(ctx.auth.currentUser);
 
-  const snapshot = await ctx.dbApi.get(
-    ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `files/${fileId}`))
-  );
+  const snapshot = await ctx.db.ref(getUserPath(user.uid, `files/${fileId}`)).get();
 
   return snapshot.exists() ? snapshot.val() : null;
 }
@@ -121,9 +153,7 @@ export async function loadRemoteIndex() {
   const ctx = await getFirebaseContext();
   const user = requireUser(ctx.auth.currentUser);
 
-  const snapshot = await ctx.dbApi.get(
-    ctx.dbApi.ref(ctx.db, getUserPath(user.uid, 'index'))
-  );
+  const snapshot = await ctx.db.ref(getUserPath(user.uid, 'index')).get();
 
   return snapshot.exists() ? snapshot.val() : {};
 }
@@ -134,19 +164,13 @@ export async function saveRemoteFile(fileId, payload) {
   const user = requireUser(ctx.auth.currentUser);
   const updatedAt = payload?.updatedAt || Date.now();
 
-  await ctx.dbApi.set(
-    ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `files/${fileId}`)),
-    { ...payload, updatedAt }
-  );
+  await ctx.db.ref(getUserPath(user.uid, `files/${fileId}`)).set({ ...payload, updatedAt });
 
-  await ctx.dbApi.set(
-    ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `index/${fileId}`)),
-    {
-      fileId,
-      updatedAt,
-      blockCount: Array.isArray(payload?.blocks) ? payload.blocks.length : 0
-    }
-  );
+  await ctx.db.ref(getUserPath(user.uid, `index/${fileId}`)).set({
+    fileId,
+    updatedAt,
+    blockCount: Array.isArray(payload?.blocks) ? payload.blocks.length : 0
+  });
 
   return { fileId, updatedAt };
 }
@@ -157,8 +181,8 @@ export async function deleteRemoteFile(fileId) {
   const user = requireUser(ctx.auth.currentUser);
 
   await Promise.all([
-    ctx.dbApi.remove(ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `files/${fileId}`))),
-    ctx.dbApi.remove(ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `index/${fileId}`)))
+    ctx.db.ref(getUserPath(user.uid, `files/${fileId}`)).remove(),
+    ctx.db.ref(getUserPath(user.uid, `index/${fileId}`)).remove()
   ]);
 
   return { fileId };


### PR DESCRIPTION
### Motivation
- Packaged Tauri WebViews can block or behave differently for remote dynamic ESM `import()` from gstatic, which caused Firebase initialization and Realtime Database sync to fail in the packaged app.
- Ensure cloud sync (auth + Realtime Database reads/writes) works reliably in both dev and packaged environments without adding new native dependencies.

### Description
- Rewrote `src/firebaseClient.js` to stop using dynamic `import()` of ESM Firebase modules and instead load the Firebase compat SDK via injected `<script>` tags (`firebase-app-compat.js`, `firebase-auth-compat.js`, `firebase-database-compat.js`) and initialize from `window.firebase`.
- Updated `getFirebaseContext()` to initialize and cache compat `app`, `auth`, and `db` instances and to set persistent auth using the compat API.
- Replaced prior module-based calls with compat-style calls (e.g. `ctx.db.ref(...).get()`, `ref(...).set()`, `.remove()`) and implemented `getCurrentUser()` and `onAuthStateChange()` to return/subscribe to the active compat auth user.
- All changes are contained in `src/firebaseClient.js` and keep the public sync API (`loadRemoteFile`, `loadRemoteIndex`, `saveRemoteFile`, `deleteRemoteFile`, `signInWithGoogle`, `signOutUser`) unchanged for the rest of the app.

### Testing
- Ran `npm run build` which completed successfully and produced a production `dist/` bundle (`vite build` succeeded). ✅
- Attempted `npm run tauri -- build --debug`, which exercised the front-end build but failed the Rust/tauri native build in this environment due to missing system `glib-2.0` / `pkg-config` libraries (not related to the JS Firebase changes). ⚠️
- Changes were committed to the repo (`git commit`) after verification that the JS bundle build succeeded. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f7ed23760832ebf8e1ac462e4d797)