### PR TITLE
Load Firebase compat scripts, force RTDB long-polling in Tauri, and update CSP

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self' asset: data: blob: https://www.gstatic.com https://*.googleapis.com https://*.firebaseio.com; connect-src 'self' ipc: http://ipc.localhost https://www.gstatic.com https://securetoken.googleapis.com https://identitytoolkit.googleapis.com https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.gstatic.com; font-src 'self' data: https:;"
     }
   },
   "bundle": {


### PR DESCRIPTION
### Motivation
- Replace fragile ESM `import()` of Firebase SDK hosted scripts with a deterministic loader that works inside WebViews and non-standard runtimes like Tauri.
- Force Realtime Database to use long-polling for stability in Tauri WebViews where WebSocket upgrades can be flaky.
- Allow the app WebView to load Firebase/Google resources by setting a restrictive but permissive-enough Content Security Policy in `tauri.conf.json`.

### Description
- Added a script loader (`loadScript`) and `loadFirebaseScripts` to sequentially load Firebase compat scripts listed in `FIREBASE_COMPAT_SCRIPTS` instead of using dynamic ESM imports.
- Added `isTauriRuntime` and `configureRealtimeTransport` which detect Tauri and call `firebase.database.INTERNAL.forceLongPolling()` to force long-polling for RTDB.
- Rewrote Firebase initialization to use the compat `window.firebase` API and updated authentication/DB usages to call compat methods (e.g. `firebase.auth()`, `firebase.database()`, `auth.signInWithPopup`, `db.ref(...).get()`, `ref(...).set()`, `ref(...).remove()`).
- Updated helper functions to work with the new runtime: `getCurrentUser`, `onAuthStateChange`, `signInWithGoogle`, `signOutUser`, `loadRemoteFile`, `loadRemoteIndex`, `saveRemoteFile`, and `deleteRemoteFile`.
- Updated `src-tauri/tauri.conf.json` security `csp` to allow required Google/Firebase resources and inline scripts/styles needed by the app and the loaded Firebase scripts.

### Testing
- No automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f7ed23760832ebf8e1ac462e4d797)