### PR TITLE
Firebase compat loader and Tauri RTDB/auth improvements; update CSP

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -21,7 +21,7 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": "default-src 'self' asset: data: blob: https://www.gstatic.com https://*.googleapis.com https://*.firebaseio.com; connect-src 'self' ipc: http://ipc.localhost https://www.gstatic.com https://securetoken.googleapis.com https://identitytoolkit.googleapis.com https://*.googleapis.com https://*.firebaseio.com wss://*.firebaseio.com; img-src 'self' data: blob: https:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://www.gstatic.com; font-src 'self' data: https:;"
     }
   },
   "bundle": {

--- a/src/firebaseClient.js
+++ b/src/firebaseClient.js
@@ -12,34 +12,125 @@ const REQUIRED_FIREBASE_KEYS = [
 
 const FIREBASE_SDK_VERSION = '11.7.0';
 
-let firebaseModulesPromise;
-let firebaseContextPromise;
+const FIREBASE_COMPAT_SCRIPTS = [
+  `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-app-compat.js`,
+  `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-auth-compat.js`,
+  `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-database-compat.js`
+];
 
-function loadFirebaseModules() {
-  if (!firebaseModulesPromise) {
-    firebaseModulesPromise = Promise.all([
-      import(/* @vite-ignore */ `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-app.js`),
-      import(/* @vite-ignore */ `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-auth.js`),
-      import(/* @vite-ignore */ `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-database.js`)
-    ]).then(([app, auth, database]) => ({ app, auth, database }));
+let firebaseScriptsPromise;
+let firebaseContextPromise;
+let firebaseAuthInstance = null;
+
+const FIREBASE_APP_NAME = 'arial-sync-app';
+
+function isTauriRuntime() {
+  return typeof window !== 'undefined' && (
+    Boolean(window.__TAURI__) ||
+    Boolean(window.__TAURI_INTERNALS__) ||
+    window.location?.protocol === 'tauri:'
+  );
+}
+
+function configureRealtimeTransport(firebase) {
+  if (!isTauriRuntime()) return;
+
+  // WebView network stacks can be flaky with RTDB WebSocket upgrades.
+  // Force long polling in Tauri so sync/authenticated reads-writes stay stable.
+  firebase?.database?.INTERNAL?.forceLongPolling?.();
+}
+
+
+function loadScript(src) {
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[data-firebase-sdk="${src}"]`);
+    if (existing) {
+      if (existing.dataset.loaded === 'true') {
+        resolve();
+      } else {
+        existing.addEventListener('load', () => resolve(), { once: true });
+        existing.addEventListener('error', () => reject(new Error(`Failed to load Firebase script: ${src}`)), { once: true });
+      }
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = src;
+    script.async = true;
+    script.dataset.firebaseSdk = src;
+    script.onload = () => {
+      script.dataset.loaded = 'true';
+      resolve();
+    };
+    script.onerror = () => reject(new Error(`Failed to load Firebase script: ${src}`));
+    document.head.appendChild(script);
+  });
+}
+
+function loadFirebaseScripts() {
+  if (!firebaseScriptsPromise) {
+    firebaseScriptsPromise = FIREBASE_COMPAT_SCRIPTS.reduce(
+      (chain, src) => chain.then(() => loadScript(src)),
+      Promise.resolve()
+    );
   }
-  return firebaseModulesPromise;
+  return firebaseScriptsPromise;
+}
+
+function resolveSyncApp(firebase) {
+  try {
+    return firebase.app(FIREBASE_APP_NAME);
+  } catch (_) {
+    return firebase.initializeApp(firebaseConfig, FIREBASE_APP_NAME);
+  }
 }
 
 async function getFirebaseContext() {
   if (!isFirebaseConfigured()) return null;
   if (!firebaseContextPromise) {
-    firebaseContextPromise = loadFirebaseModules().then(({ app, auth, database }) => {
-      const firebaseApp = app.getApps().length
-        ? app.getApp()
-        : app.initializeApp(firebaseConfig);
-      const firebaseAuth = auth.getAuth(firebaseApp);
-      auth.setPersistence(firebaseAuth, auth.browserLocalPersistence).catch(() => {});
-      const firebaseDb = database.getDatabase(firebaseApp);
-      return { app: firebaseApp, auth: firebaseAuth, db: firebaseDb, authApi: auth, dbApi: database };
+    firebaseContextPromise = loadFirebaseScripts().then(() => {
+      const firebase = window?.firebase;
+      if (!firebase) {
+        throw new Error('Firebase SDK failed to initialize.');
+      }
+
+      configureRealtimeTransport(firebase);
+      const app = resolveSyncApp(firebase);
+      const auth = firebase.auth(app);
+      firebaseAuthInstance = auth;
+      auth.setPersistence(firebase.auth.Auth.Persistence.LOCAL).catch(() => {});
+      finalizeRedirectSignIn(auth).catch(() => {});
+      const db = firebase.database(app);
+      return { app, auth, db };
+    }).catch(error => {
+      firebaseContextPromise = null;
+      throw error;
     });
   }
   return firebaseContextPromise;
+}
+
+
+function toMessage(error) {
+  return error?.message || String(error || 'Unknown error');
+}
+
+function isPopupFlowError(error) {
+  const code = error?.code || '';
+  return code === 'auth/popup-blocked' || code === 'auth/popup-closed-by-user' || code === 'auth/cancelled-popup-request' || code === 'auth/internal-error';
+}
+
+async function finalizeRedirectSignIn(auth) {
+  try {
+    const result = await auth.getRedirectResult();
+    return result?.user ?? null;
+  } catch (error) {
+    const code = error?.code || '';
+    if (code === 'auth/unauthorized-domain') {
+      throw new Error('Google sign-in domain is not authorized. Add tauri.localhost (and localhost) in Firebase Console → Authentication → Settings → Authorized domains.');
+    }
+    throw new Error(`Google redirect sign-in failed: ${toMessage(error)}`);
+  }
 }
 
 function normalizeNamespace() {
@@ -64,7 +155,7 @@ export function isFirebaseConfigured() {
 }
 
 export function getCurrentUser() {
-  return null;
+  return firebaseAuthInstance?.currentUser ?? null;
 }
 
 export function onAuthStateChange(callback) {
@@ -77,7 +168,7 @@ export function onAuthStateChange(callback) {
         callback?.(null);
         return;
       }
-      unsub = ctx.authApi.onAuthStateChanged(ctx.auth, callback);
+      unsub = ctx.auth.onAuthStateChanged(callback);
     })
     .catch(() => {
       callback?.(null);
@@ -93,15 +184,37 @@ export async function signInWithGoogle() {
   const ctx = await getFirebaseContext();
   if (!ctx) throw new Error('Firebase is not configured.');
 
-  const provider = new ctx.authApi.GoogleAuthProvider();
-  const result = await ctx.authApi.signInWithPopup(ctx.auth, provider);
-  return result.user;
+  const firebase = window?.firebase;
+  if (!firebase?.auth?.GoogleAuthProvider) {
+    throw new Error('Firebase Auth SDK is unavailable.');
+  }
+
+  const provider = new firebase.auth.GoogleAuthProvider();
+  provider.setCustomParameters({ prompt: 'select_account' });
+
+  try {
+    const result = await ctx.auth.signInWithPopup(provider);
+    return result.user;
+  } catch (error) {
+    const code = error?.code || '';
+
+    if (code === 'auth/unauthorized-domain') {
+      throw new Error('Google sign-in domain is not authorized. Add tauri.localhost (and localhost) in Firebase Console → Authentication → Settings → Authorized domains.');
+    }
+
+    if (isTauriRuntime() && isPopupFlowError(error)) {
+      await ctx.auth.signInWithRedirect(provider);
+      return null;
+    }
+
+    throw new Error(`Google sign-in failed: ${toMessage(error)}`);
+  }
 }
 
 export async function signOutUser() {
   const ctx = await getFirebaseContext();
   if (!ctx) return;
-  await ctx.authApi.signOut(ctx.auth);
+  await ctx.auth.signOut();
 }
 
 export async function loadRemoteFile(fileId) {
@@ -109,9 +222,7 @@ export async function loadRemoteFile(fileId) {
   const ctx = await getFirebaseContext();
   const user = requireUser(ctx.auth.currentUser);
 
-  const snapshot = await ctx.dbApi.get(
-    ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `files/${fileId}`))
-  );
+  const snapshot = await ctx.db.ref(getUserPath(user.uid, `files/${fileId}`)).get();
 
   return snapshot.exists() ? snapshot.val() : null;
 }
@@ -121,9 +232,7 @@ export async function loadRemoteIndex() {
   const ctx = await getFirebaseContext();
   const user = requireUser(ctx.auth.currentUser);
 
-  const snapshot = await ctx.dbApi.get(
-    ctx.dbApi.ref(ctx.db, getUserPath(user.uid, 'index'))
-  );
+  const snapshot = await ctx.db.ref(getUserPath(user.uid, 'index')).get();
 
   return snapshot.exists() ? snapshot.val() : {};
 }
@@ -134,19 +243,13 @@ export async function saveRemoteFile(fileId, payload) {
   const user = requireUser(ctx.auth.currentUser);
   const updatedAt = payload?.updatedAt || Date.now();
 
-  await ctx.dbApi.set(
-    ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `files/${fileId}`)),
-    { ...payload, updatedAt }
-  );
+  await ctx.db.ref(getUserPath(user.uid, `files/${fileId}`)).set({ ...payload, updatedAt });
 
-  await ctx.dbApi.set(
-    ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `index/${fileId}`)),
-    {
-      fileId,
-      updatedAt,
-      blockCount: Array.isArray(payload?.blocks) ? payload.blocks.length : 0
-    }
-  );
+  await ctx.db.ref(getUserPath(user.uid, `index/${fileId}`)).set({
+    fileId,
+    updatedAt,
+    blockCount: Array.isArray(payload?.blocks) ? payload.blocks.length : 0
+  });
 
   return { fileId, updatedAt };
 }
@@ -157,8 +260,8 @@ export async function deleteRemoteFile(fileId) {
   const user = requireUser(ctx.auth.currentUser);
 
   await Promise.all([
-    ctx.dbApi.remove(ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `files/${fileId}`))),
-    ctx.dbApi.remove(ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `index/${fileId}`)))
+    ctx.db.ref(getUserPath(user.uid, `files/${fileId}`)).remove(),
+    ctx.db.ref(getUserPath(user.uid, `index/${fileId}`)).remove()
   ]);
 
   return { fileId };


### PR DESCRIPTION
### Motivation
- Make Firebase work reliably inside the Tauri WebView by loading the compat SDK, stabilizing RealTime Database transport, and improving the Google sign-in flow for popup-restricted environments.
- Tighten the app Content Security Policy to permit the Firebase assets and required connections for auth and RTDB.

### Description
- Updated `src-tauri/tauri.conf.json` to set a CSP that allows Firebase scripts, Google auth endpoints, and required asset/connect sources.
- Replaced modular dynamic imports with a script loader that injects Firebase compat scripts (`firebase-app-compat`, `firebase-auth-compat`, `firebase-database-compat`) and initializes a named Firebase app.
- Added runtime detection for Tauri and forced RTDB long-polling in that environment via `configureRealtimeTransport` to avoid flaky WebSocket upgrades in WebViews.
- Reworked auth and DB usage to the compat API: store an auth instance, expose `getCurrentUser`, use `onAuthStateChange` with the compat `auth` object, implement `signInWithGoogle` with popup handling and redirect fallback for popup-blocked cases, and replace modular `db` API calls with compat `db.ref(...).get()/set()/remove()` calls.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f7ed23760832ebf8e1ac462e4d797)