### PR TITLE
Enable Tauri devtools and log RTDB connectivity

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "width": 800,
         "height": 600,
         "resizable": true,
-        "fullscreen": false
+        "fullscreen": false,
+        "devtools": true
       }
     ],
     "security": {

--- a/src/firebaseClient.js
+++ b/src/firebaseClient.js
@@ -36,6 +36,9 @@ async function getFirebaseContext() {
       const firebaseAuth = auth.getAuth(firebaseApp);
       auth.setPersistence(firebaseAuth, auth.browserLocalPersistence).catch(() => {});
       const firebaseDb = database.getDatabase(firebaseApp);
+      database.onValue(database.ref(firebaseDb, '.info/connected'), snap => {
+        console.log('RTDB .info/connected =', snap.val(), Date.now());
+      });
       return { app: firebaseApp, auth: firebaseAuth, db: firebaseDb, authApi: auth, dbApi: database };
     });
   }


### PR DESCRIPTION
### Motivation
- Enable webview devtools in packaged Tauri builds for easier debugging and add RTDB connectivity logging to detect unstable realtime transport that can cause `set()` to hang.

### Description
- Set `"devtools": true` on the main window in `src-tauri/tauri.conf.json` so packaged apps can open the webview devtools.
- Added an `.info/connected` listener immediately after creating the RTDB instance in `src/firebaseClient.js` using `database.onValue(database.ref(firebaseDb, '.info/connected'), ...)` to log true/false connectivity flips with timestamps.

### Testing
- Ran `npm run build` from the project root and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f98f28998832e941fb6b4eaa51135)