### PR TITLE
Fix mobile canvas pinch zoom resetting after gesture end

### DIFF
--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -22,6 +22,7 @@
   let baseScale = 1; 
   let lastDistance = null;
   let isMobile = false;
+  let hasUserZoomed = false;
 
 
 
@@ -65,6 +66,7 @@
       newScale = Math.max(baseScale * 0.5, Math.min(baseScale * 3, newScale)); 
 
       scale = newScale;
+      hasUserZoomed = true;
       lastDistance = newDistance;
 
       e.preventDefault();
@@ -89,6 +91,7 @@
     baseScale = Math.min(scaleX, scaleY);
 
     scale = baseScale;
+    hasUserZoomed = false;
     inner.style.transformOrigin = "top left";
   }
 
@@ -99,11 +102,14 @@
   }
 
   function checkIsMobile() {
+    const wasMobile = isMobile;
     isMobile = window.innerWidth <= 1024;
-    if (isMobile) {
+
+    if (isMobile && (!hasUserZoomed || !wasMobile)) {
       fitCanvasToScreen();
-    } else {
+    } else if (!isMobile) {
       scale = 1; // reset scale on desktop
+      hasUserZoomed = false;
     }
   }
 

--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -20,6 +20,7 @@
 
   let scale = 1;
   let baseScale = 1; 
+  let userZoom = 1;
   let lastDistance = null;
   let isMobile = false;
   let hasUserZoomed = false;
@@ -66,6 +67,7 @@
       newScale = Math.max(baseScale * 0.5, Math.min(baseScale * 3, newScale)); 
 
       scale = newScale;
+      userZoom = scale / baseScale;
       hasUserZoomed = true;
       lastDistance = newDistance;
 
@@ -77,7 +79,7 @@
     lastDistance = null;
   }
 
-  function fitCanvasToScreen() {
+  function fitCanvasToScreen({ resetUserZoom = false } = {}) {
     if (!canvasRef) return;
     const inner = canvasRef.querySelector(".canvas-inner");
     if (!inner) return;
@@ -90,14 +92,18 @@
     const scaleY = availableHeight / 1080;
     baseScale = Math.min(scaleX, scaleY);
 
-    scale = baseScale;
-    hasUserZoomed = false;
+    if (resetUserZoom) {
+      userZoom = 1;
+      hasUserZoomed = false;
+    }
+
+    scale = baseScale * userZoom;
     inner.style.transformOrigin = "top left";
   }
 
   export function refitCanvas() {
     tick().then(() => {
-      fitCanvasToScreen();
+      fitCanvasToScreen({ resetUserZoom: true });
     });
   }
 
@@ -105,10 +111,11 @@
     const wasMobile = isMobile;
     isMobile = window.innerWidth <= 1024;
 
-    if (isMobile && (!hasUserZoomed || !wasMobile)) {
-      fitCanvasToScreen();
+    if (isMobile) {
+      fitCanvasToScreen({ resetUserZoom: !hasUserZoomed || !wasMobile });
     } else if (!isMobile) {
       scale = 1; // reset scale on desktop
+      userZoom = 1;
       hasUserZoomed = false;
     }
   }


### PR DESCRIPTION
### Motivation
- Users reported that pinch-zooming the canvas on mobile briefly zooms during the gesture but snaps back to the default scale on touch end or on resize, breaking expected behavior.

### Description
- Added a `hasUserZoomed` flag to `src/Modes/CanvasMode.svelte` to remember when the user has performed a manual pinch zoom via `onTouchMove` and set it to `true` when a user-driven scale change occurs.
- Updated `fitCanvasToScreen()` to reset the `hasUserZoomed` flag only when an intentional refit is performed by the app, leaving user-applied zoom intact otherwise.
- Changed `checkIsMobile()` logic to only auto-refit when first entering mobile mode or before the user has zoomed, and to reset `hasUserZoomed` when switching back to desktop.

### Testing
- Ran `npm run build` and the production build completed successfully with Vite (build output produced and chunks rendered).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d56e871f2c832eaebdb750cf3f9035)