### PR TITLE
Fix Simple Note mode blocks stopping after first columns

### DIFF
--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -96,12 +96,11 @@
 <style>
 /* ========== MOBILE (default) ========== */
 .simple-wrapper {
-  display: block;
-  column-count: 2;
-  column-gap: 1rem;
-  column-fill: balance;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
   padding: clamp(12px, 2vw, 24px);
-  overflow: visible;
+  overflow-y: auto;
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;
@@ -113,12 +112,9 @@
   background: var(--canvas-outer-bg, #00000041);
   border-radius: 8px;
   padding: 5px;
-  margin: 0 0 1rem;
+  margin: 0;
   display: block;
   width: auto;
-  break-inside: avoid-column;
-  page-break-inside: avoid;
-  -webkit-column-break-inside: avoid;
   box-sizing: border-box;
 }
 
@@ -212,10 +208,9 @@ li {
 }
 
 .footer {
-  height: 600px;
+  height: 120px;
   width: 100%;
   background: #000;
-  column-span: all;
 }
 
 
@@ -224,8 +219,6 @@ li {
   .simple-wrapper {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    column-count: auto;
-    column-gap: 0;
     gap: 1rem;
     justify-content: stretch;
     max-width: 1400px;
@@ -238,7 +231,6 @@ li {
 
   .footer {
     grid-column: 1 / -1;
-    column-span: none;
   }
 
   .container img {


### PR DESCRIPTION
### Motivation
- The simple-note mobile layout used CSS multi-column flow which could stop rendering subsequent blocks after the first visible columns, making later blocks unreachable.
- The layout needed to be a predictable vertical flow with scrolling so all blocks render and remain reachable on small viewports.

### Description
- Reworked `src/Modes/SimpleNoteMode.svelte` CSS to use a grid single-column flow for mobile by changing `.simple-wrapper` from multi-column to `display: grid` with `grid-template-columns: 1fr` and `gap: 1rem`.
- Removed column-break related rules (`break-inside`, page-/webkit- column break rules) from `.canvas` so blocks remain in normal document flow.
- Set `.simple-wrapper` to `overflow-y: auto` and reduced `.footer` height from `600px` to `120px` to avoid oversized spacer interfering with block visibility.
- Cleaned up desktop rules by removing column-span/column-gap artifacts while preserving the existing desktop grid behavior.

### Testing
- Ran `npm run build` which completed successfully and produced the production bundles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbd8b09504832e83c367374ac29bcc)