### PR TITLE
Match Simple Note footer background to canvas theme

### DIFF
--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -218,6 +218,7 @@
   display: flex;
   gap: 1rem;
   align-items: flex-start;
+  background: var(--canvas-inner-bg, #000000);
   padding: clamp(12px, 2vw, 24px);
   overflow-y: auto;
   overflow-x: hidden;

--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -406,7 +406,7 @@ li {
     display: block;
     height: 600px;
     width: 100%;
-    background: #000;
+    background: var(--canvas-inner-bg, #000000);
     grid-column: 1 / -1;
     column-span: none;
   }


### PR DESCRIPTION
### Motivation
- The desktop footer filler in `SimpleNoteMode` was hardcoded black and should follow the active canvas/theme background like `CanvasMode` so column backgrounds stay visually consistent.

### Description
- Replaced the hardcoded `background: #000;` with `background: var(--canvas-inner-bg, #000000);` in the `.footer` rule inside `src/Modes/SimpleNoteMode.svelte` so the footer uses the canvas inner background CSS variable.

### Testing
- Ran `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe3a9cf44832eaccee47a707533db)