### PR TITLE
SimpleNote: unify layout to mobile-style columns and add configurable column count

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -149,6 +149,23 @@
   const LAST_SAVE_STORAGE_KEY = 'lastLoadedSave';
   const BOOT_LOAD_GUARD_STORAGE_KEY = 'bootLoadGuard';
   const FALLBACK_SAVE_NAME = 'Fallback';
+  const DEFAULT_MODE_SETTINGS = {
+    simple: {
+      columnCount: 2
+    }
+  };
+
+  function normalizeModeSettings(settings) {
+    const incomingSimple = settings?.simple || {};
+    return {
+      ...DEFAULT_MODE_SETTINGS,
+      simple: {
+        ...DEFAULT_MODE_SETTINGS.simple,
+        ...incomingSimple,
+        columnCount: Math.max(1, Number.parseInt(incomingSimple.columnCount, 10) || DEFAULT_MODE_SETTINGS.simple.columnCount)
+      }
+    };
+  }
 
   function loadStoredCustomThemes() {
     if (typeof localStorage === 'undefined') return [];
@@ -751,7 +768,8 @@
   let observedControlsEl;
 
   let mode = getDefaultModeForViewport();
-  let simpleNoteColumnCount = 2;
+  let modeSettings = normalizeModeSettings();
+  $: simpleNoteColumnCount = modeSettings.simple.columnCount;
   let blocks = [];
   let modeOrders = {};
   let normalizedModeOrders = ensureModeOrders(blocks, modeOrders);
@@ -828,13 +846,14 @@
     }
   }
 
-  async function persistAutosave(blocksToPersist, ordersToPersist = modeOrders) {
+  async function persistAutosave(blocksToPersist, ordersToPersist = modeOrders, settingsToPersist = modeSettings) {
     if (!currentSaveName) return;
     persistLastSaveName(currentSaveName);
     const normalizedOrders = ensureModeOrders(blocksToPersist, ordersToPersist);
     await saveBlocks(currentSaveName, {
       blocks: blocksToPersist,
-      modeOrders: normalizedOrders
+      modeOrders: normalizedOrders,
+      modeSettings: normalizeModeSettings(settingsToPersist)
     });
     savedList = await listSavedBlocks();
   }
@@ -1072,6 +1091,9 @@
       const loadedOrders = !Array.isArray(loaded)
         ? loaded?.modeOrders
         : {};
+      const loadedModeSettings = !Array.isArray(loaded)
+        ? loaded?.modeSettings
+        : null;
 
       currentSaveName = name;
       persistLastSaveName(name);
@@ -1080,6 +1102,7 @@
         _version: 0
       }));
       modeOrders = ensureModeOrders(blocks, loadedOrders);
+      modeSettings = normalizeModeSettings(loadedModeSettings);
 
       history = [];
       historyIndex = -1;
@@ -1222,7 +1245,8 @@
     const dataStr = JSON.stringify(
       {
         blocks,
-        modeOrders: ensureModeOrders(blocks, modeOrders)
+        modeOrders: ensureModeOrders(blocks, modeOrders),
+        modeSettings: normalizeModeSettings(modeSettings)
       },
       null,
       2
@@ -1252,11 +1276,15 @@
           const importedOrders = Array.isArray(imported)
             ? {}
             : imported.modeOrders;
+          const importedModeSettings = Array.isArray(imported)
+            ? null
+            : imported.modeSettings;
           blocks = importedBlocks.map(b => ({
             ...applyHistoryTriggers(b),
             _version: 0
           }));
           modeOrders = ensureModeOrders(blocks, importedOrders);
+          modeSettings = normalizeModeSettings(importedModeSettings);
           focusedBlockId = null;
           history = [];
           historyIndex = -1;
@@ -1291,6 +1319,22 @@
 
     const height = controlsRef?.offsetHeight || 56;
     setControlsHeight(height);
+  }
+
+  async function handleModeSettingChange(event) {
+    const nextColumnCount = Math.max(
+      1,
+      Number.parseInt(event.detail?.columnCount, 10) || DEFAULT_MODE_SETTINGS.simple.columnCount
+    );
+    const nextModeSettings = normalizeModeSettings({
+      ...modeSettings,
+      simple: {
+        ...modeSettings.simple,
+        columnCount: nextColumnCount
+      }
+    });
+    modeSettings = nextModeSettings;
+    await persistAutosave(blocks, modeOrders, nextModeSettings);
   }
 
   function setupControlsObserver() {
@@ -1668,6 +1712,7 @@
         on:update={updateBlockHandler}
         on:delete={deleteBlockHandler}
         on:focusToggle={handleFocusToggle}
+        on:modeSettingChange={handleModeSettingChange}
       />
     {/key}
   </div>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -751,6 +751,7 @@
   let observedControlsEl;
 
   let mode = getDefaultModeForViewport();
+  let simpleNoteColumnCount = 2;
   let blocks = [];
   let modeOrders = {};
   let normalizedModeOrders = ensureModeOrders(blocks, modeOrders);
@@ -1658,6 +1659,7 @@
       <ModeArea
         {mode}
         blocks={modeOrderedBlocks}
+        {simpleNoteColumnCount}
         {groupedBlocks}
         {focusedBlockId}
         modeLabels={MODE_LABELS}

--- a/src/Modes/ModeSwitcher.svelte
+++ b/src/Modes/ModeSwitcher.svelte
@@ -34,6 +34,10 @@
     dispatch('focusToggle', event.detail);
   }
 
+  function modeSettingChangeHandler(event) {
+    dispatch('modeSettingChange', event.detail);
+  }
+
   function updateWidth() {
     width = window.innerWidth;
   }
@@ -74,6 +78,7 @@
       on:update={updateBlockHandler}
       on:delete={deleteBlockHandler}
       on:focusToggle={focusToggleHandler}
+      on:columnCountChange={modeSettingChangeHandler}
     />
 
   {:else if mode === 'habit'}

--- a/src/Modes/ModeSwitcher.svelte
+++ b/src/Modes/ModeSwitcher.svelte
@@ -16,6 +16,7 @@
   export let focusedBlockId;
   export let canvasColors = {};
   export let modeLabels = {};
+  export let simpleNoteColumnCount = 2;
 
   let width = 0;
 
@@ -64,6 +65,7 @@
     <SimpleNoteMode
       {blocks}
       {focusedBlockId}
+      columnCount={simpleNoteColumnCount}
       bind:canvasRef
       {canvasColors}
       on:touchstart={onTouchStart}

--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -5,8 +5,8 @@
   export let focusedBlockId = null;
   export let canvasColors = {};
   export let canvasRef;
+  export let columnCount = 2;
   const dispatch = createEventDispatcher();
-  let isMobile = false;
 
   const defaultCanvasColors = {
     outerBg: '#000000',
@@ -168,15 +168,10 @@
     }
   }
 
-  function updateViewportMode() {
-    if (typeof window === 'undefined') return;
-    isMobile = window.innerWidth < 1024;
-  }
-
-  $: mobileColumns = [
-    blocks.filter((_, index) => index % 2 === 0),
-    blocks.filter((_, index) => index % 2 === 1)
-  ];
+  $: normalizedColumnCount = Math.max(1, Number.parseInt(columnCount, 10) || 2);
+  $: renderColumns = Array.from({ length: normalizedColumnCount }, (_, columnIndex) =>
+    blocks.filter((_, blockIndex) => blockIndex % normalizedColumnCount === columnIndex)
+  );
   
 
 
@@ -184,10 +179,8 @@
   // Resize all textareas when component mounts
   onMount(() => {
     let rafId;
-    window.addEventListener('resize', updateViewportMode);
     
     const initializeLayout = async () => {
-      updateViewportMode();
       await tick();
       resizeAllTextareas();
       rafId = requestAnimationFrame(() => {
@@ -197,7 +190,6 @@
     initializeLayout();
 
     return () => {
-      window.removeEventListener('resize', updateViewportMode);
       if (rafId) cancelAnimationFrame(rafId);
     };
   });
@@ -215,7 +207,8 @@
 <style>
 /* ========== MOBILE (default) ========== */
 .simple-wrapper {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(var(--simple-note-columns, 2), minmax(0, 1fr));
   gap: 1rem;
   align-items: flex-start;
   background: var(--canvas-inner-bg, #000000);
@@ -223,8 +216,8 @@
   overflow-y: auto;
   overflow-x: hidden;
   width: 100%;
-  max-width: 1200px;
-  margin: 0 auto;
+  max-width: none;
+  margin: 0;
   min-width: 0;
   box-sizing: border-box;
 }
@@ -377,55 +370,6 @@ li {
   margin-right: 10px;
 }
 
-.footer {
-  display: none;
-}
-
-
-/* ========== PC (desktop) ========== */
-@media (min-width: 1024px) {
-  .simple-wrapper {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-    column-count: auto;
-    column-gap: 0;
-    gap: 1rem;
-    justify-content: stretch;
-    max-width: 1400px;
-  }
-
-  .canvas {
-    display: block;
-    margin-bottom: 0;
-  }
-
-  .simple-column {
-    display: contents;
-  }
-
-  .footer {
-    display: block;
-    height: 600px;
-    width: 100%;
-    background: var(--canvas-inner-bg, #000000);
-    grid-column: 1 / -1;
-    column-span: none;
-  }
-
-  .container img {
-    width: auto;
-    height: 100%;
-    max-height: 500px;
-    object-fit: contain;
-    border-radius: 14px;
-  }
-}
-
-
-
-
-
-
 </style>
 
 
@@ -436,129 +380,10 @@ li {
 
 
 
-<div class="simple-wrapper" bind:this={canvasRef} style={canvasCssVars}>
-  {#if isMobile}
-    {#each mobileColumns as column}
-      <div class="simple-column">
-        {#each column as block (blockKey(block))}
-          <div class="canvas">
-            <div
-              class="container"
-              class:focused={block.id === focusedBlockId}
-              style="--bg-color: {block.bgColor}; --text-color: {block.textColor};"
-              on:click={(event) => handleBlockClick(event, block.id)}
-              role="button"
-              tabindex="0"
-              aria-pressed={block.id === focusedBlockId}
-              on:keydown={(event) => handleBlockKeydown(event, block.id)}
-            >
-              {#if block.type === 'text' || block.type === 'cleantext'}
-                <textarea
-                  bind:value={block.content}
-                  spellcheck="false"
-                  rows="1"
-                  style="overflow:hidden;"
-                  on:input={(e) => {
-                    updateBlock(block.id, { content: e.target.value }, { pushToHistory: false, changedKeys: ['content'] });
-                  }}
-                  on:focus={(e) => {
-                    focusScroll(e.target);
-                    ensureFocus(block.id);
-                  }}
-                  data-focus-guard
-                  placeholder="Type your note here..."
-                ></textarea>
-                <button class="delete-button" on:click|stopPropagation={() => deleteBlock(block.id)} data-focus-guard>
-                ×
-                </button>
-              {:else if block.type === 'image'}
-                {#if hasImageSource(block)}
-                  <img
-                    src={getImageSource(block)}
-                    alt=""
-                    data-focus-guard
-                    on:dblclick|stopPropagation={() => openImagePicker(block.id)}
-                    on:touchend|stopPropagation={(event) => handleImageTouchEnd(event, block)}
-                  />
-                {:else}
-                  <div class="image-empty-state" data-focus-guard>
-                    <button
-                      class="image-select-button"
-                      on:click|stopPropagation={() => openImagePicker(block.id)}
-                      data-focus-guard
-                    >
-                      Add image
-                    </button>
-                  </div>
-                {/if}
-                <li>
-                  <input
-                    type="file"
-                    accept="image/*"
-                    style="display:none;"
-                    use:imageInputRef={block.id}
-                    on:change={(event) => handleImageChange(event, block)}
-                    data-focus-guard
-                  />
-                  <button
-                    class="edit-button"
-                    data-focus-guard
-                    on:click={() =>
-                      updateBlock(block.id, { editing: !block.editing })
-                    }
-                  >
-                    {block.editing ? 'Done' : 'Edit'}
-                  </button>
-                  {#if block.editing}
-                    <input
-                      type="text"
-                      placeholder="Image URL"
-                      value={block.src}
-                      on:input={(e) => updateBlock(block.id, { src: e.target.value })}
-                      on:focus={() => ensureFocus(block.id)}
-                      data-focus-guard
-                    />
-                  {/if}
-                  <button class="delete-button" on:click|stopPropagation={() => deleteBlock(block.id)} data-focus-guard>
-                    ×
-                  </button>
-                </li>
-
-              {:else if block.type === 'music'}
-                <p>🎵 {block.content}</p>
-                <button class="delete-button" on:click|stopPropagation={() => deleteBlock(block.id)} data-focus-guard>
-                ×
-                </button>
-              {:else if block.type === 'embed'}
-                <p>[Embed: {block.content}]</p>
-                <button class="delete-button" on:click|stopPropagation={() => deleteBlock(block.id)} data-focus-guard>
-                ×
-                </button>
-              {:else if block.type === 'task'}
-                <div class="task-list-title">{block.title || 'Task List'}</div>
-                <div class="task-list">
-                  {#if Array.isArray(block.tasks) && block.tasks.length}
-                    {#each block.tasks as task (task.id)}
-                      <div class="task-item">
-                        {task.done ? '✅' : '⬜'} {task.text}
-                      </div>
-                    {/each}
-                  {:else}
-                    <div class="task-item">No tasks yet</div>
-                  {/if}
-                </div>
-                <button class="delete-button" on:click|stopPropagation={() => deleteBlock(block.id)} data-focus-guard>
-                ×
-                </button>
-              {/if}
-
-            </div>
-          </div>
-        {/each}
-      </div>
-    {/each}
-  {:else}
-    {#each blocks as block (blockKey(block))}
+<div class="simple-wrapper" bind:this={canvasRef} style={`${canvasCssVars} --simple-note-columns: ${normalizedColumnCount};`}>
+  {#each renderColumns as column}
+    <div class="simple-column">
+      {#each column as block (blockKey(block))}
       <div class="canvas">
         <div
           class="container"
@@ -673,7 +498,7 @@ li {
 
         </div>
       </div>
-    {/each}
-    <div class="footer"></div>
-  {/if}
+      {/each}
+    </div>
+  {/each}
 </div>

--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -172,6 +172,11 @@
   $: renderColumns = Array.from({ length: normalizedColumnCount }, (_, columnIndex) =>
     blocks.filter((_, blockIndex) => blockIndex % normalizedColumnCount === columnIndex)
   );
+
+  function handleColumnGaugeInput(event) {
+    const next = Math.max(1, Number.parseInt(event.currentTarget.value, 10) || 1);
+    dispatch('columnCountChange', { columnCount: next });
+  }
   
 
 
@@ -220,6 +225,36 @@
   margin: 0;
   min-width: 0;
   box-sizing: border-box;
+}
+
+.simple-toolbar {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding: 0 0.25rem;
+}
+
+.simple-toolbar label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #ffffff;
+  font-weight: 700;
+  background: color-mix(in srgb, var(--canvas-outer-bg, #000000) 60%, transparent);
+  border: 1px solid color-mix(in srgb, #ffffff 25%, transparent);
+  border-radius: 999px;
+  padding: 0.4rem 0.75rem;
+}
+
+.simple-toolbar input[type="range"] {
+  width: min(220px, 36vw);
+}
+
+.simple-toolbar-value {
+  min-width: 1.25rem;
+  text-align: center;
 }
 
 .simple-column {
@@ -370,6 +405,12 @@ li {
   margin-right: 10px;
 }
 
+@media (max-width: 1023px) {
+  .simple-toolbar {
+    display: none;
+  }
+}
+
 </style>
 
 
@@ -381,6 +422,20 @@ li {
 
 
 <div class="simple-wrapper" bind:this={canvasRef} style={`${canvasCssVars} --simple-note-columns: ${normalizedColumnCount};`}>
+  <div class="simple-toolbar">
+    <label>
+      Columns
+      <input
+        type="range"
+        min="1"
+        max="6"
+        step="1"
+        value={normalizedColumnCount}
+        on:input={handleColumnGaugeInput}
+      />
+      <span class="simple-toolbar-value">{normalizedColumnCount}</span>
+    </label>
+  </div>
   {#each renderColumns as column}
     <div class="simple-column">
       {#each column as block (blockKey(block))}


### PR DESCRIPTION
### Motivation
- Make the Simple Note mode behave like the mobile UI on desktop so notes take the full available canvas and blocks expand to fill space depending on column count. 
- Allow configuring the number of columns so users (or future UI controls) can change how blocks are distributed and sized across the screen.

### Description
- Added a `columnCount` prop to `SimpleNoteMode.svelte` and compute `renderColumns` by distributing `blocks` into `columnCount` columns. 
- Switched `.simple-wrapper` to a CSS grid driven by `--simple-note-columns` so columns expand to fill available width and blocks widen accordingly. 
- Removed the old desktop-only render branch / `isMobile` logic and the footer, consolidating rendering to a single column-based flow. 
- Threaded a `simpleNoteColumnCount` variable from `App.svelte` through `ModeSwitcher.svelte` into `SimpleNoteMode` so column count can be controlled from parent state.

### Testing
- Ran the production build with `npm run build` (Vite) and the build completed successfully. 
- The build emitted the usual bundle size warnings but finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbe66bec8c832eb7ae47abcee94811)