### PR TITLE
Prevent mobile canvas de-zoom when editing blocks

### DIFF
--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -24,6 +24,7 @@
   let lastDistance = null;
   let isMobile = false;
   let hasUserZoomed = false;
+  let lastViewportWidth = null;
 
 
 
@@ -99,6 +100,7 @@
 
     scale = baseScale * userZoom;
     inner.style.transformOrigin = "top left";
+    lastViewportWidth = window.innerWidth;
   }
 
   export function refitCanvas() {
@@ -111,12 +113,24 @@
     const wasMobile = isMobile;
     isMobile = window.innerWidth <= 1024;
 
+    const activeTag = document.activeElement?.tagName?.toLowerCase();
+    const isEditableFocused =
+      activeTag === 'textarea' ||
+      activeTag === 'input' ||
+      document.activeElement?.isContentEditable;
+    const viewportWidthChanged =
+      lastViewportWidth === null || Math.abs(window.innerWidth - lastViewportWidth) > 1;
+
     if (isMobile) {
+      if (wasMobile && isEditableFocused && !viewportWidthChanged) {
+        return;
+      }
       fitCanvasToScreen({ resetUserZoom: !hasUserZoomed || !wasMobile });
     } else if (!isMobile) {
       scale = 1; // reset scale on desktop
       userZoom = 1;
       hasUserZoomed = false;
+      lastViewportWidth = null;
     }
   }
 

--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -1,6 +1,5 @@
 <script>
   import { createEventDispatcher } from 'svelte';
-  import { onMount, tick } from 'svelte';
   import TexteBlock from '../components/TexteBlock.svelte';
   import ImgBlock from '../components/ImgBlock.svelte';
   import Texteclean from '../components/TexteClean.svelte';
@@ -19,12 +18,7 @@
   
 
   let scale = 1;
-  let baseScale = 1; 
-  let userZoom = 1;
   let lastDistance = null;
-  let isMobile = false;
-  let hasUserZoomed = false;
-  let isCanvasReady = false;
 
 
 
@@ -52,24 +46,20 @@
   }
 
   function onTouchStart(e) {
-    if (!isMobile) return;
     if (e.touches.length === 2) {
       lastDistance = getDistance(e.touches);
     }
   }
 
   function onTouchMove(e) {
-    if (!isMobile) return;
     if (e.touches.length === 2 && lastDistance) {
       const newDistance = getDistance(e.touches);
       const diff = newDistance - lastDistance;
 
       let newScale = scale + diff * 0.005;
-      newScale = Math.max(baseScale * 0.5, Math.min(baseScale * 3, newScale)); 
+      newScale = Math.max(0.5, Math.min(3, newScale));
 
       scale = newScale;
-      userZoom = scale / baseScale;
-      hasUserZoomed = true;
       lastDistance = newDistance;
 
       e.preventDefault();
@@ -80,34 +70,6 @@
     lastDistance = null;
   }
 
-  function fitCanvasToScreen({ resetUserZoom = false } = {}) {
-    if (!canvasRef) return;
-    const inner = canvasRef.querySelector(".canvas-inner");
-    if (!inner) return;
-
-    const controlsHeight = parseInt(getComputedStyle(document.documentElement).getPropertyValue("--controls-height")) || 56;
-    const availableWidth = window.innerWidth;
-    const availableHeight = window.innerHeight - controlsHeight;
-
-    const scaleX = availableWidth / 1920;
-    const scaleY = availableHeight / 1080;
-    baseScale = Math.min(scaleX, scaleY);
-
-    if (resetUserZoom) {
-      userZoom = 1;
-      hasUserZoomed = false;
-    }
-
-    scale = baseScale * userZoom;
-    inner.style.transformOrigin = "top left";
-  }
-
-  export function refitCanvas() {
-    tick().then(() => {
-      fitCanvasToScreen({ resetUserZoom: true });
-    });
-  }
-
   const defaultCanvasColors = {
     outerBg: '#000000',
     innerBg: '#000000'
@@ -115,21 +77,7 @@
 
   $: canvasTheme = { ...defaultCanvasColors, ...(canvasColors || {}) };
   $: canvasCssVars = `--canvas-outer-bg: ${canvasTheme.outerBg}; --canvas-inner-bg: ${canvasTheme.innerBg};`;
-  $: innerScale = isMobile ? scale : 1;
-
-  onMount(() => {
-    isMobile = window.innerWidth <= 1024;
-
-    if (isMobile) {
-      fitCanvasToScreen({ resetUserZoom: true });
-    } else {
-      scale = 1;
-      userZoom = 1;
-      hasUserZoomed = false;
-    }
-
-    isCanvasReady = true;
-  });
+  $: innerScale = scale;
 </script>
 
 
@@ -143,12 +91,6 @@
   background: var(--canvas-outer-bg, rgb(0, 0, 0));
   overflow: auto;
 }
-
-.canvas.loading {
-  visibility: hidden;
-}
-
-
 
 .canvas-inner {
   width: 1800px;
@@ -181,7 +123,6 @@
 
 <div
   class="canvas"
-  class:loading={!isCanvasReady}
   class:simple-note={mode === 'simple'}
   bind:this={canvasRef}
   style={canvasCssVars}

--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -24,6 +24,7 @@
   let lastDistance = null;
   let isMobile = false;
   let hasUserZoomed = false;
+  let isCanvasReady = false;
 
 
 
@@ -126,6 +127,8 @@
       userZoom = 1;
       hasUserZoomed = false;
     }
+
+    isCanvasReady = true;
   });
 </script>
 
@@ -139,6 +142,10 @@
   bottom: 0;
   background: var(--canvas-outer-bg, rgb(0, 0, 0));
   overflow: auto;
+}
+
+.canvas.loading {
+  visibility: hidden;
 }
 
 
@@ -174,6 +181,7 @@
 
 <div
   class="canvas"
+  class:loading={!isCanvasReady}
   class:simple-note={mode === 'simple'}
   bind:this={canvasRef}
   style={canvasCssVars}

--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -107,22 +107,6 @@
     });
   }
 
-  function checkIsMobile() {
-    const wasMobile = isMobile;
-    isMobile = window.innerWidth <= 1024;
-
-    if (isMobile) {
-      if (wasMobile) {
-        return;
-      }
-      fitCanvasToScreen({ resetUserZoom: true });
-    } else if (!isMobile) {
-      scale = 1; // reset scale on desktop
-      userZoom = 1;
-      hasUserZoomed = false;
-    }
-  }
-
   const defaultCanvasColors = {
     outerBg: '#000000',
     innerBg: '#000000'
@@ -133,11 +117,15 @@
   $: innerScale = isMobile ? scale : 1;
 
   onMount(() => {
-    checkIsMobile();
-    window.addEventListener("resize", checkIsMobile);
-    return () => {
-      window.removeEventListener("resize", checkIsMobile);
-    };
+    isMobile = window.innerWidth <= 1024;
+
+    if (isMobile) {
+      fitCanvasToScreen({ resetUserZoom: true });
+    } else {
+      scale = 1;
+      userZoom = 1;
+      hasUserZoomed = false;
+    }
   });
 </script>
 

--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -24,7 +24,6 @@
   let lastDistance = null;
   let isMobile = false;
   let hasUserZoomed = false;
-  let lastViewportWidth = null;
 
 
 
@@ -100,7 +99,6 @@
 
     scale = baseScale * userZoom;
     inner.style.transformOrigin = "top left";
-    lastViewportWidth = window.innerWidth;
   }
 
   export function refitCanvas() {
@@ -113,24 +111,15 @@
     const wasMobile = isMobile;
     isMobile = window.innerWidth <= 1024;
 
-    const activeTag = document.activeElement?.tagName?.toLowerCase();
-    const isEditableFocused =
-      activeTag === 'textarea' ||
-      activeTag === 'input' ||
-      document.activeElement?.isContentEditable;
-    const viewportWidthChanged =
-      lastViewportWidth === null || Math.abs(window.innerWidth - lastViewportWidth) > 1;
-
     if (isMobile) {
-      if (wasMobile && isEditableFocused && !viewportWidthChanged) {
+      if (wasMobile) {
         return;
       }
-      fitCanvasToScreen({ resetUserZoom: !hasUserZoomed || !wasMobile });
+      fitCanvasToScreen({ resetUserZoom: true });
     } else if (!isMobile) {
       scale = 1; // reset scale on desktop
       userZoom = 1;
       hasUserZoomed = false;
-      lastViewportWidth = null;
     }
   }
 


### PR DESCRIPTION
### Motivation
- Fix unintended canvas "de-zoom" on mobile that occurs when the soft keyboard or other height-only viewport changes happen while interacting with block inputs.
- Preserve expected behavior for real viewport width/orientation changes and maintain the existing desktop reset behavior.

### Description
- Added a `lastViewportWidth` variable and updated `fitCanvasToScreen` in `src/Modes/CanvasMode.svelte` to cache the current viewport width after fitting.
- Added a guard in `checkIsMobile` to detect focused editable elements (`input`, `textarea`, contenteditable) and to skip refitting when only the viewport height changed (no significant width change).
- Clear the cached `lastViewportWidth` when leaving mobile mode so desktop reset behavior remains unchanged.

### Testing
- Ran `npm run build` which runs `vite build`, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc0aa50618832ea5af60bfd692197e)