### PR TITLE
Tighten Simple Note spacing and apply block colors in Single Note mode

### DIFF
--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -214,10 +214,10 @@
 .simple-wrapper {
   display: grid;
   grid-template-columns: repeat(var(--simple-note-columns, 2), minmax(0, 1fr));
-  gap: 1rem;
+  gap: 0.55rem;
   align-items: flex-start;
   background: var(--canvas-inner-bg, #000000);
-  padding: clamp(12px, 2vw, 24px);
+  padding: clamp(6px, 1.1vw, 12px);
   overflow-y: auto;
   overflow-x: hidden;
   width: 100%;
@@ -266,7 +266,7 @@
   background: var(--canvas-outer-bg, #00000041);
   border-radius: 8px;
   padding: 5px;
-  margin: 0 0 1rem;
+  margin: 0 0 0.45rem;
   display: block;
   width: auto;
   break-inside: avoid-column;

--- a/src/Modes/SingleNoteMode.svelte
+++ b/src/Modes/SingleNoteMode.svelte
@@ -15,7 +15,9 @@
 
   $: canvasTheme = { ...defaultCanvasColors, ...(canvasColors || {}) };
   $: modeTextColor = getReadableTextColor(canvasTheme.innerBg);
-  $: canvasCssVars = `--canvas-outer-bg: ${canvasTheme.outerBg}; --canvas-inner-bg: ${canvasTheme.innerBg}; --mode-text-color: ${modeTextColor};`;
+  $: activeNoteBg = noteBlock?.bgColor || canvasTheme.innerBg;
+  $: activeNoteText = noteBlock?.textColor || getReadableTextColor(activeNoteBg);
+  $: canvasCssVars = `--canvas-outer-bg: ${canvasTheme.outerBg}; --canvas-inner-bg: ${canvasTheme.innerBg}; --mode-text-color: ${modeTextColor}; --active-note-bg: ${activeNoteBg}; --active-note-text: ${activeNoteText};`;
 
   $: noteBlocks = blocks.filter(
     block => block.type === 'text' || block.type === 'cleantext'
@@ -127,6 +129,12 @@
     }
     return `Note ${index + 1}`;
   }
+
+  function getTabStyle(block) {
+    const bg = block?.bgColor || canvasTheme.outerBg;
+    const text = block?.textColor || getReadableTextColor(bg);
+    return `--tab-bg: ${bg}; --tab-text: ${text};`;
+  }
 </script>
 
 <style>
@@ -148,9 +156,9 @@
   }
 
   .note-tab {
-    border: 1px solid rgba(255, 255, 255, 0.25);
-    background: transparent;
-    color: inherit;
+    border: 1px solid color-mix(in srgb, var(--tab-text, #ffffff) 50%, transparent);
+    background: color-mix(in srgb, var(--tab-bg, #000000) 88%, #000000 12%);
+    color: var(--tab-text, inherit);
     padding: 6px 12px;
     border-radius: 999px;
     font-size: 0.85rem;
@@ -159,8 +167,9 @@
   }
 
   .note-tab[aria-selected='true'] {
-    border-color: rgba(255, 255, 255, 0.8);
-    background: rgba(255, 255, 255, 0.12);
+    border-color: var(--tab-text, rgba(255, 255, 255, 0.8));
+    background: var(--tab-bg, rgba(255, 255, 255, 0.12));
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--tab-text, #ffffff) 55%, transparent);
   }
 
   .note-tab:focus-visible {
@@ -177,6 +186,8 @@
     width: 100%;
     padding: 8px 12px;
     box-sizing: border-box;
+    background: color-mix(in srgb, var(--active-note-bg, #000000) 38%, transparent);
+    color: var(--active-note-text, inherit);
   }
 
   .note-stats {
@@ -199,8 +210,8 @@
     border: none;
     resize: none;
     padding: 12px;
-    background: var(--canvas-inner-bg, #000000);
-    color: var(--mode-text-color, #ffffff);
+    background: var(--active-note-bg, var(--canvas-inner-bg, #000000));
+    color: var(--active-note-text, var(--mode-text-color, #ffffff));
     font-family: Arial, Helvetica, sans-serif;
     font-size: 1.05rem;
     line-height: 1.6;
@@ -222,7 +233,7 @@
   .note-footer button {
     background: transparent;
     border: none;
-    color: var(--mode-text-color, #ffffff);
+    color: var(--active-note-text, var(--mode-text-color, #ffffff));
     font-size: 1.1rem;
     cursor: pointer;
   }
@@ -255,6 +266,7 @@
             class="note-tab"
             role="tab"
             aria-selected={block.id === selectedNoteId}
+            style={getTabStyle(block)}
             on:click={() => {
               selectedNoteId = block.id;
             }}


### PR DESCRIPTION
### Motivation
- Make the Simple Note layout denser by reducing gaps and margins so notes sit closer together and nearer screen edges.
- Have Single Note mode visually reflect the selected note's `bgColor`/`textColor` so the editor area and tabs follow block colors for better visual continuity.

### Description
- Reduced grid gap, wrapper padding, and per-block bottom margin in `src/Modes/SimpleNoteMode.svelte` to tighten spacing (`gap`, `padding`, `margin`).
- Added reactive `activeNoteBg` and `activeNoteText` vars and extended `canvasCssVars` in `src/Modes/SingleNoteMode.svelte` so the editor area uses the selected note's colors.
- Added `getTabStyle` and applied inline `style` to note-selection tabs so each tab can show its block colors, and updated `.note-tab`, `.note-meta`, `.note-footer`, and `textarea` CSS to use the new CSS variables.
- Minor selected-state emphasis for tabs via adjusted border/background and subtle box-shadow to improve visibility.

### Testing
- Ran `npm run build` and the production build completed successfully.
- No automated unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca5b6ea44832ea540e6ab65c879c6)