### PR TITLE
Match single-note footer to active note color and tighten simple-note padding

### DIFF
--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -217,7 +217,7 @@
   gap: 0.55rem;
   align-items: flex-start;
   background: var(--canvas-inner-bg, #000000);
-  padding: clamp(6px, 1.1vw, 12px);
+  padding: clamp(3px, 0.55vw, 6px);
   overflow-y: auto;
   overflow-x: hidden;
   width: 100%;

--- a/src/Modes/SingleNoteMode.svelte
+++ b/src/Modes/SingleNoteMode.svelte
@@ -228,6 +228,7 @@
     display: flex;
     justify-content: flex-end;
     padding: 6px 12px 10px;
+    background: var(--active-note-bg, var(--canvas-inner-bg, #000000));
   }
 
   .note-footer button {


### PR DESCRIPTION
### Motivation
- Make the Single Note mode footer visually match the currently selected note color and remove any redundant footer label text if present.
- Reduce the outer padding in Simple Note mode so blocks sit closer to the sides of the screen, roughly halving the previous distance.

### Description
- Updated `.note-footer` in `src/Modes/SingleNoteMode.svelte` to use `background: var(--active-note-bg, var(--canvas-inner-bg, #000000));` so the footer matches the active note color.
- Reduced the `.simple-wrapper` padding in `src/Modes/SimpleNoteMode.svelte` from `clamp(6px, 1.1vw, 12px)` to `clamp(3px, 0.55vw, 6px)` to tighten spacing near screen edges.
- No explicit footer label removal was required because the Single Note markup contains only the icon-only delete control and no visible footer text.

### Testing
- Ran `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca7e426f8832e8986b49bc10ffa21)