### PR TITLE
Use active simple-note text color for mode tab accent and improve mobile controls layout

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -770,6 +770,11 @@
   let mode = getDefaultModeForViewport();
   let modeSettings = normalizeModeSettings();
   $: simpleNoteColumnCount = modeSettings.simple.columnCount;
+  $: activeSimpleNoteColor = (() => {
+    if (mode !== 'simple') return null;
+    const focusedBlock = modeOrderedBlocks.find((block) => block.id === focusedBlockId);
+    return focusedBlock?.textColor || null;
+  })();
   let blocks = [];
   let modeOrders = {};
   let normalizedModeOrders = ensureModeOrders(blocks, modeOrders);
@@ -1647,6 +1652,7 @@
     <LeftControls
       bind:currentSaveName
       {mode}
+      activeModeAccent={activeSimpleNoteColor}
       modeLabels={MODE_LABELS}
       {blocks}
       {savedList}

--- a/src/advanced-param/LeftControls.svelte
+++ b/src/advanced-param/LeftControls.svelte
@@ -6,6 +6,7 @@
   export let currentSaveName;
   export let focusedBlockId = null;
   export let colors = {};
+  export let activeModeAccent = null;
   export let birthdayModeUnlocked = false;
   export let birthdayUnlockMessage = '';
 
@@ -61,6 +62,7 @@
   })
     .map(([name, value]) => `${name}: ${value}`)
     .join("; ");
+  $: modeAccentColor = activeModeAccent || theme.buttonText || '#ffffff';
 
 
   $: isSingleNoteMode = mode === "single";
@@ -239,8 +241,10 @@ onMount(() => {
   }
 
   .mode-ladder button.active {
-    background: rgba(127, 211, 255, 0.2);
-    border-color: rgba(127, 211, 255, 0.5);
+    background: transparent;
+    border-color: var(--mode-active-outline, currentColor);
+    color: var(--mode-active-outline, currentColor);
+    border-width: 2px;
   }
 
 
@@ -315,12 +319,13 @@ onMount(() => {
 
   .mobile-quick-actions {
     display: none;
-    position: fixed;
-    top: 29px;
-    left: 94px;
-    z-index: 1000;
+    position: relative;
+    z-index: 1001;
     align-items: center;
     gap: 6px;
+    margin-left: auto;
+    flex-wrap: nowrap;
+    max-width: 100%;
   }
 
   .mobile-block-actions {
@@ -335,12 +340,15 @@ onMount(() => {
       gap: 6px;
       background: var(--left-panel-bg, #111111b0);
       padding: 10px;
-      border-radius: 0 0 8px 0;
+      border-radius: 12px;
       position: absolute;
-      top: 71px;
-      left: 0px;
-      z-index: 999;
+      top: calc(100% + 8px);
+      left: 8px;
+      right: 8px;
+      z-index: 1002;
       box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+      max-height: min(70vh, 540px);
+      overflow-y: auto;
     }
     .left-controls.show {
       display: flex;
@@ -351,7 +359,7 @@ onMount(() => {
 
     .mobile-quick-actions {
       display: inline-flex;
-      left: 10px;
+      justify-content: flex-end;
     }
 
     .mobile-only {
@@ -364,10 +372,26 @@ onMount(() => {
       gap: 6px;
 
     }
+
+    .left-controls-wrapper button,
+    .left-controls-wrapper input {
+      min-height: 40px;
+    }
+
+    .mode-switcher,
+    .add-block-menu {
+      width: 100%;
+    }
+
+    .mode-switcher > button,
+    .add-block-menu > button {
+      width: 100%;
+      justify-content: center;
+    }
   }
 </style>
 
-<div class="left-controls-wrapper" style={leftCssVars}>
+<div class="left-controls-wrapper" style={`${leftCssVars}; --mode-active-outline: ${modeAccentColor};`}>
   <!-- Toggle button for <= 1024px -->
   {#if compactUI}
 


### PR DESCRIPTION
### Motivation
- Make the mode tab reflect the selected note color in Simple Note Mode by showing an outline in the note's text color, and improve touch-targets and panel layout for phone screens.

### Description
- Add a reactive `activeSimpleNoteColor` in `src/App.svelte` that returns the focused simple-note block's `textColor` when `mode === 'simple'` and pass it to `LeftControls` as `activeModeAccent`.
- Accept `activeModeAccent` in `src/advanced-param/LeftControls.svelte`, compute `modeAccentColor`, and expose it as the CSS variable `--mode-active-outline` on the controls wrapper.
- Update `.mode-ladder button.active` styling to an outline-only treatment that uses `--mode-active-outline` for border and text so the active tab matches the selected note color.
- Improve mobile ergonomics in `LeftControls.svelte` by repositioning `mobile-quick-actions` into the top bar, widening and rounding the mobile controls panel, adding `max-height` and `overflow-y:auto`, increasing button/input touch sizes to `min-height:40px`, and making mode/add-block buttons full-width for easier tapping.

### Testing
- Ran `npm run build`, which completed successfully producing a production bundle, with only non-blocking warnings about chunk size and one unused CSS selector; build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcac1f2580832ea5218bef798a9f97)