### PR TITLE
Tighten mobile menu width and align thin action buttons

### DIFF
--- a/src/advanced-param/LeftControls.svelte
+++ b/src/advanced-param/LeftControls.svelte
@@ -310,6 +310,18 @@ onMount(() => {
   }
 
 
+  .thin-button-row {
+    display: inline-flex;
+    gap: 8px;
+  }
+
+  .thin-action-btn {
+    width: 54px;
+    min-width: 54px;
+    padding-inline: 0;
+    justify-content: center;
+  }
+
   .compact-toggle-btn {
     display: none;
   }
@@ -331,7 +343,7 @@ onMount(() => {
     .left-controls {
       display: none;
       flex-direction: column;
-      align-items: flex-start;
+      align-items: stretch;
       gap: 8px;
       background: var(--left-panel-bg, #111111f0);
       padding: 12px;
@@ -340,11 +352,35 @@ onMount(() => {
       top: calc(var(--controls-height, 56px) + 8px);
       left: 8px;
       right: auto;
-      width: min(320px, calc(100vw - 16px));
+      width: min(260px, calc(100vw - 16px));
       max-height: calc(100dvh - var(--controls-height, 56px) - 16px);
       overflow: auto;
       z-index: 1002;
       box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+    }
+
+    .left-controls > button,
+    .left-controls > input,
+    .left-controls > .mode-switcher,
+    .left-controls > .add-block-menu {
+      width: 100%;
+    }
+
+    .left-controls > input {
+      max-width: 100%;
+      box-sizing: border-box;
+    }
+
+    .left-controls .thin-button-row {
+      width: 100%;
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 8px;
+    }
+
+    .left-controls .thin-action-btn {
+      width: 100%;
+      min-width: 0;
     }
     .left-controls.show {
       display: flex;
@@ -501,22 +537,26 @@ onMount(() => {
         </div>
       {/if}
     </div>
-    <button
-      on:click={moveUp}
-      disabled={!focusedBlockId}
-      aria-label="Move block down"
-      title="Move block down"
-    >
-      ⬇
-    </button>
-    <button
-      on:click={moveDown}
-      disabled={!focusedBlockId}
-      aria-label="Move block up"
-      title="Move block up"
-    >
-      ⬆
-    </button>
+    <div class="thin-button-row">
+      <button
+        class="thin-action-btn"
+        on:click={moveUp}
+        disabled={!focusedBlockId}
+        aria-label="Move block down"
+        title="Move block down"
+      >
+        ⬇
+      </button>
+      <button
+        class="thin-action-btn"
+        on:click={moveDown}
+        disabled={!focusedBlockId}
+        aria-label="Move block up"
+        title="Move block up"
+      >
+        ⬆
+      </button>
+    </div>
     <button on:click={clear}>🗑️ Clear</button>
     <button on:click={exportJSON}>⬇ Export</button>
     <button on:click={triggerFileInput}>📁 Import JSON</button>


### PR DESCRIPTION
### Motivation
- Reduce the compact/mobile left menu width and make the file-name input match the width of other compact controls to avoid an overly wide menu. 
- Place the two small move buttons on a single horizontal row so they appear as a thin grouped control while keeping other actions in a vertical column.

### Description
- Added a `.thin-button-row` wrapper and `.thin-action-btn` CSS rules and updated the markup to group the two move buttons into that row in `src/advanced-param/LeftControls.svelte`.
- Changed compact/mobile menu layout by switching `.left-controls` to `align-items: stretch` and reducing its max width from `min(320px, ...)` to `min(260px, ...)` inside the `@media (max-width: 1024px)` block.
- Constrained top-level controls inside the compact menu so `button`, `input`, `.mode-switcher`, and `.add-block-menu` stretch to the menu width, and adjusted `.thin-button-row` to render as a two-column grid at mobile sizes.
- Ensured the file-name input (`currentSaveName`) now obeys the compact width rules by adding `max-width: 100%` and `box-sizing: border-box` for mobile.

### Testing
- Ran a production build with `npm run build`, which completed successfully (build produced only warnings about bundle size and one unused CSS selector). 
- Attempted `npm run check` but the project has no `check` script so that command could not be run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcc558c184832eb355e908f1273f98)