### PR TITLE
Adjust mobile birthday unlock row sizing

### DIFF
--- a/src/advanced-param/LeftControls.svelte
+++ b/src/advanced-param/LeftControls.svelte
@@ -287,6 +287,19 @@ onMount(() => {
     width: 100%;
   }
 
+  .birthday-unlock-row input {
+    flex: 1 1 auto;
+    min-width: 0;
+    width: auto;
+  }
+
+  .birthday-unlock-row button {
+    flex: 0 0 auto;
+    width: auto;
+    white-space: nowrap;
+    padding-inline: 10px;
+  }
+
   .birthday-unlock small {
     opacity: 0.85;
   }
@@ -426,15 +439,6 @@ onMount(() => {
       min-width: 120px;
     }
 
-    .birthday-unlock-row input {
-      flex: 1 1 0;
-      min-width: 0;
-    }
-
-    .birthday-unlock-row button {
-      flex: 0 0 auto;
-      white-space: nowrap;
-    }
   }
 </style>
 

--- a/src/advanced-param/LeftControls.svelte
+++ b/src/advanced-param/LeftControls.svelte
@@ -284,6 +284,7 @@ onMount(() => {
   .birthday-unlock-row {
     display: flex;
     gap: 6px;
+    width: 100%;
   }
 
   .birthday-unlock small {
@@ -423,6 +424,16 @@ onMount(() => {
     .add-block-list {
       width: min(140px, calc(100vw - 16px));
       min-width: 120px;
+    }
+
+    .birthday-unlock-row input {
+      flex: 1 1 0;
+      min-width: 0;
+    }
+
+    .birthday-unlock-row button {
+      flex: 0 0 auto;
+      white-space: nowrap;
     }
   }
 </style>


### PR DESCRIPTION
### Motivation
- The mobile mode menu's birthday unlock row (password + Unlock button) could exceed or not align with other full-width menu controls, so the row needs to collapse to the same total width and let the input share available space while keeping the Unlock button intrinsic width.

### Description
- Set `.birthday-unlock-row` to span the container by adding `width: 100%` in `src/advanced-param/LeftControls.svelte`.
- In the mobile media query, make the password input flexible with `flex: 1 1 0` and `min-width: 0` so it shrinks within the row (`.birthday-unlock-row input`).
- Keep the Unlock button intrinsic width with `flex: 0 0 auto` and `white-space: nowrap` so it does not collapse (`.birthday-unlock-row button`).

### Testing
- Ran `npm run build` and the production build completed successfully (only pre-existing Svelte/Vite warnings were reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcd0903cb8832ebf82d964e929faac)