### PR TITLE
Improve Simple Note layout density on mobile

### DIFF
--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -409,6 +409,32 @@ li {
   .simple-toolbar {
     display: none;
   }
+
+  .simple-wrapper {
+    grid-template-columns: 1fr;
+    gap: 0.3rem;
+    padding: 2px;
+  }
+
+  .simple-column {
+    width: 100%;
+  }
+
+  .canvas {
+    width: 100%;
+    margin: 0 0 0.25rem;
+    padding: 3px;
+  }
+
+  .container {
+    width: 100%;
+    border-radius: 14px;
+    padding: 2px;
+  }
+
+  textarea {
+    padding: 8px;
+  }
 }
 
 </style>


### PR DESCRIPTION
### Motivation
- Maximize usable horizontal space and reduce vertical gaps on phones so images and long text lines occupy more of the viewport and notes feel denser on mobile.

### Description
- Add mobile-specific CSS in `src/Modes/SimpleNoteMode.svelte` to force a single full-width column, reduce wrapper gap/padding, make `.simple-column`, `.canvas`, and `.container` explicitly full-width, and slightly reduce `textarea` padding.

### Testing
- Ran `npm run build` successfully (build completed; only non-blocking warnings about an unused CSS selector and large chunk sizes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df08a14c40832ea57b73d6b69a1af0)