### PR TITLE
Improve Simple Note mobile layout density

### DIFF
--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -406,6 +406,27 @@ li {
 }
 
 @media (max-width: 1023px) {
+  .simple-wrapper {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.35rem;
+    padding: 2px;
+  }
+
+  .canvas {
+    margin-bottom: 0.3rem;
+    padding: 3px;
+    border-radius: 6px;
+  }
+
+  .container {
+    padding: 3px;
+    border-radius: 14px;
+  }
+
+  textarea {
+    padding: 8px;
+  }
+
   .simple-toolbar {
     display: none;
   }


### PR DESCRIPTION
### Motivation
- Make Simple Note Mode use the full horizontal space on phones and reduce card spacing so images and long text lines are not cramped on mobile screens.

### Description
- In `src/Modes/SimpleNoteMode.svelte` added rules under `@media (max-width: 1023px)` to force a single-column grid (`grid-template-columns: minmax(0, 1fr)`), reduce wrapper `gap` and `padding`, tighten `.canvas` and `.container` margin/padding/border-radius, and reduce `textarea` padding while keeping the mobile toolbar hidden.

### Testing
- Ran `npm run build` which completed successfully (build finished with a reusable bundle; there were non-fatal warnings about an unused CSS selector and chunk sizes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcfc12ed8c832eb35e61c2112133e4)