### PR TITLE
Match Simple Note focus styling to note background color

### DIFF
--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -294,9 +294,9 @@
 }
 
 .container.focused {
-  outline: 2px solid var(--bg-color);
-  box-shadow: 0 0 0 2px color-mix(in srgb, var(--bg-color) 55%, transparent),
-              0 0 12px color-mix(in srgb, var(--bg-color) 75%, transparent);
+  outline: 4px solid var(--bg-color);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--bg-color) 55%, transparent),
+              0 0 14px color-mix(in srgb, var(--bg-color) 75%, transparent);
 }
 
 textarea {
@@ -316,9 +316,9 @@ textarea {
 }
 
 textarea:focus {
-  color: var(--text-color);
+  color: var(--bg-color);
   outline: none;
-  background: var(--bg-color);
+  background: var(--text-color);
 }
 
 textarea::selection {

--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -294,9 +294,9 @@
 }
 
 .container.focused {
-  outline: 2px solid rgba(110, 168, 255, 0.85);
-  box-shadow: 0 0 0 2px rgba(110, 168, 255, 0.35),
-              0 0 12px rgba(110, 168, 255, 0.5);
+  outline: 2px solid var(--bg-color);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--bg-color) 55%, transparent),
+              0 0 12px color-mix(in srgb, var(--bg-color) 75%, transparent);
 }
 
 textarea {
@@ -316,9 +316,14 @@ textarea {
 }
 
 textarea:focus {
-  color: var(--bg-color);
+  color: var(--text-color);
   outline: none;
-  background: var(--text-color);
+  background: var(--bg-color);
+}
+
+textarea::selection {
+  background: var(--bg-color);
+  color: var(--text-color);
 }
 
 .container img {


### PR DESCRIPTION
### Motivation
- Make the focus outline, glow and text selection in Simple Note mode match each note's own background color so focused/selected text feels consistent with the note's palette.

### Description
- Updated `.container.focused` in `src/Modes/SimpleNoteMode.svelte` to use `--bg-color` for the outline and `color-mix` for the glow instead of a fixed blue color.
- Changed `textarea:focus` so the focused textarea keeps the note background (`background: var(--bg-color)`) and retains `--text-color` rather than inverting colors on focus.
- Added `textarea::selection` styling so selected text uses the note's `--bg-color` and `--text-color`.

### Testing
- Ran `npm run build` and the build completed successfully (production bundle generated).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df0b769bdc832e9bc0d4d57ed01e8e)