### PR TITLE
Remove focus highlight color in Simple Note mode

### DIFF
--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -294,9 +294,9 @@
 }
 
 .container.focused {
-  outline: 2px solid rgba(110, 168, 255, 0.85);
-  box-shadow: 0 0 0 2px rgba(110, 168, 255, 0.35),
-              0 0 12px rgba(110, 168, 255, 0.5);
+  outline: 2px solid transparent;
+  box-shadow: 0 0 2px 1px var(--text-color),
+              0 0 6px 2px var(--text-color);
 }
 
 textarea {


### PR DESCRIPTION
### Motivation
- Remove the blue focus highlight from focused blocks in Simple Note mode so focused blocks use the neutral container appearance instead of a colored accent.

### Description
- Update `.container.focused` in `src/Modes/SimpleNoteMode.svelte` to use a transparent outline and the same neutral `box-shadow` as the default `.container` (replacing the blue `rgba(110, 168, 255, ...)` styles).

### Testing
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df0f23e580832eb192223848bb2733)