### PR TITLE
Make Simple Note mode respect theme shadow settings

### DIFF
--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -284,8 +284,8 @@
   border-radius: 20px;
   overflow: hidden;
   border: 2px solid var(--text-color);
-  box-shadow: 0 0 2px 1px var(--text-color),
-              0 0 6px 2px var(--text-color);
+  box-shadow: var(--block-shadow, 0 0 2px 1px var(--text-color),
+              0 0 6px 2px var(--text-color));
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -294,8 +294,9 @@
 }
 
 .container.focused {
-  outline: 4px solid transparent;
-
+  outline-color: var(--block-focus-outline, transparent);
+  box-shadow: var(--block-focus-shadow, var(--block-shadow, 0 0 2px 1px var(--text-color),
+              0 0 6px 2px var(--text-color)));
 }
 
 textarea {


### PR DESCRIPTION
### Motivation
- Ensure Simple Note mode note cards and focused state follow the active theme's shadow and focus settings so themes that disable or customize shadows apply consistently across modes.

### Description
- Updated `src/Modes/SimpleNoteMode.svelte` to use `--block-shadow` for the note container shadow with the original shadow kept as a fallback.
- Updated the focused container to use `--block-focus-outline` for outline color and `--block-focus-shadow` with a fallback to `--block-shadow`.
- Kept original visual fallbacks so existing themes without these variables behave the same.

### Testing
- Ran the production build with `npm run build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df125cfc88832e8e7a16e332b35c91)