### PR TITLE
Fix undo/redo remounting for moved text blocks

### DIFF
--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -216,7 +216,7 @@
         style:transform={`scale(${scale})`}
         style:background={canvasTheme.innerBg || defaultCanvasColors.innerBg}
       >
-      {#each blocks as block (block.id + (block.type !== 'text' && block.type !== 'cleantext' ? '-' + (block._version || 0) : ''))}
+      {#each blocks as block (`${block.id}-${block._version || 0}`)}
         {#if block.type === 'text'}
           <TexteBlock
             id={block.id}

--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -85,7 +85,7 @@
   }
 
   function blockKey(block) {
-    return block.id + (block.type !== 'text' && block.type !== 'cleantext' ? '-' + (block._version || 0) : '');
+    return `${block.id}-${block._version || 0}`;
   }
 
   let imageInputRefs = {};


### PR DESCRIPTION
### Motivation
- Undo/redo for text blocks stopped working correctly when moving a block because text block components keep local `position`/`size` state and were not being remounted on state snapshots.
- The root cause was that text/cleantext blocks were excluded from the versioned render key, so parent snapshots that bump `_version` did not force a component remount.

### Description
- Updated the keyed `{#each}` rendering in `src/Modes/CanvasMode.svelte` to use ```${block.id}-${block._version || 0}``` so all block types (including `text`/`cleantext`) remount when `_version` changes.
- Aligned `src/Modes/SimpleNoteMode.svelte` by changing `blockKey` to return ```${block.id}-${block._version || 0}``` for consistent keying across modes.
- This ensures components with internal position/size state receive fresh props via remount when history snapshots are applied.

### Testing
- Ran `npm run build` which completed successfully and produced the production bundle.
- The build emitted existing non-fatal warnings (an unused CSS selector and chunk-size warnings) but no build failures occurred.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df1f7894e0832eab81fdebd279db45)