### PR TITLE
Stabilize undo/redo history sequencing

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -831,14 +831,23 @@
   let history = [];
   let historyIndex = -1;
   let hasUnsnapshottedChanges = false;
+  let historyOperationQueue = Promise.resolve();
 
-  async function ensureCurrentHistorySnapshot() {
+  function queueHistoryOperation(operation) {
+    const nextOperation = historyOperationQueue.then(operation);
+    historyOperationQueue = nextOperation.catch(error => {
+      console.error("History operation failed:", error);
+    });
+    return nextOperation;
+  }
+
+  async function ensureCurrentHistorySnapshotInternal() {
     if (!blocks.length && history.length) return;
 
     if (!hasUnsnapshottedChanges) return;
 
     if (!history.length) {
-      await pushHistory(blocks, modeOrders);
+      await pushHistoryInternal(blocks, modeOrders);
       return;
     }
 
@@ -851,7 +860,7 @@
     const latestHistorySnapshot = history[historyIndex];
 
     if (latestHistorySnapshot !== currentSnapshot) {
-      await pushHistory(blocks, modeOrders);
+      await pushHistoryInternal(blocks, modeOrders);
     } else {
       hasUnsnapshottedChanges = false;
     }
@@ -869,7 +878,7 @@
     savedList = await listSavedBlocks();
   }
 
-  async function pushHistory(newBlocks, newOrders = modeOrders) {
+  async function pushHistoryInternal(newBlocks, newOrders = modeOrders) {
     const stateSnapshot = cloneState(newBlocks, newOrders, { bumpVersion: true });
     const snapshot = JSON.stringify(stateSnapshot);
 
@@ -894,8 +903,14 @@
     hasUnsnapshottedChanges = false;
   }
 
-  async function undo() {
-    await ensureCurrentHistorySnapshot();
+  function pushHistory(newBlocks, newOrders = modeOrders) {
+    return queueHistoryOperation(() =>
+      pushHistoryInternal(newBlocks, newOrders)
+    );
+  }
+
+  async function undoInternal() {
+    await ensureCurrentHistorySnapshotInternal();
 
     if (historyIndex > 0) {
       historyIndex--;
@@ -913,10 +928,15 @@
       blocks = [...snapshotBlocks];
       modeOrders = cloneModeOrders(snapshotOrders);
       await persistAutosave(snapshotBlocks, snapshotOrders);
+      hasUnsnapshottedChanges = false;
     }
   }
 
-  async function redo() {
+  async function undo() {
+    await queueHistoryOperation(() => undoInternal());
+  }
+
+  async function redoInternal() {
     if (historyIndex < history.length - 1) {
       historyIndex++;
       const snapshotState = JSON.parse(history[historyIndex]) || {};
@@ -933,20 +953,30 @@
       blocks = [...snapshotBlocks];
       modeOrders = cloneModeOrders(snapshotOrders);
       await persistAutosave(snapshotBlocks, snapshotOrders);
+      hasUnsnapshottedChanges = false;
     }
+  }
+
+  async function redo() {
+    await queueHistoryOperation(() => redoInternal());
   }
 
   function handleUndoRedoShortcut(event) {
     const key = event.key?.toLowerCase();
     const hasCommand = event.ctrlKey || event.metaKey;
-    if (!hasCommand || key !== "z") return;
+    const isUndo = hasCommand && key === "z" && !event.shiftKey;
+    const isRedoShortcut =
+      hasCommand && key === "z" && event.shiftKey;
+    const isCtrlYRedo =
+      event.ctrlKey && !event.metaKey && key === "y";
+    if (!isUndo && !isRedoShortcut && !isCtrlYRedo) return;
 
     event.preventDefault();
 
-    if (event.shiftKey) {
-      redo();
+    if (isRedoShortcut || isCtrlYRedo) {
+      void redo();
     } else {
-      undo();
+      void undo();
     }
   }
 


### PR DESCRIPTION
### Motivation
- Undo/redo was intermittent and could corrupt state when async autosave/history work interleaved with rapid user actions, so history operations need serialized sequencing.
- Keyboard redo semantics were incomplete (Ctrl/Cmd+Shift+Z and Ctrl+Y should both be supported for redo across platforms).

### Description
- Introduce a single promise queue `historyOperationQueue` and helper `queueHistoryOperation` to serialize all history mutations and prevent overlapping async operations.
- Split history logic into internal helpers (`ensureCurrentHistorySnapshotInternal`, `pushHistoryInternal`, `undoInternal`, `redoInternal`) and route public `pushHistory`, `undo`, and `redo` through the queue for safe composition and no re-entrancy.
- Ensure `hasUnsnapshottedChanges` is explicitly cleared after undo/redo restores to keep snapshot state consistent.
- Improve keyboard handling to support both `Cmd/Ctrl+Shift+Z` and `Ctrl+Y` as redo while keeping `Cmd/Ctrl+Z` for undo.

### Testing
- Ran `npm run build` and the build completed successfully (Vite emitted non-blocking warnings about an unused CSS selector and chunk size, but the production build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df20daa094832ebf283c5533b3671a)