### PR TITLE
Ignore no-op block updates to stabilize undo/redo

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -894,6 +894,28 @@
     hasUnsnapshottedChanges = false;
   }
 
+  function updatedBlockValueForKey(key, existingBlock, blockUpdates) {
+    if (key === 'position') {
+      return { ...existingBlock.position, ...(blockUpdates.position || {}) };
+    }
+    if (key === 'size') {
+      return { ...existingBlock.size, ...(blockUpdates.size || {}) };
+    }
+    return blockUpdates[key];
+  }
+
+  function areHistoryValuesEqual(previousValue, nextValue) {
+    if (
+      previousValue &&
+      nextValue &&
+      typeof previousValue === 'object' &&
+      typeof nextValue === 'object'
+    ) {
+      return JSON.stringify(previousValue) === JSON.stringify(nextValue);
+    }
+    return previousValue === nextValue;
+  }
+
   async function undo() {
     await ensureCurrentHistorySnapshot();
 
@@ -1018,11 +1040,21 @@
         ? changedKeys
         : Object.keys(updates);
 
+    const actualChangedKeys = normalizedChangedKeys.filter(key => {
+      const previousValue = existing[key];
+      const nextValue = updatedBlockValueForKey(key, existing, updates);
+      return !areHistoryValuesEqual(previousValue, nextValue);
+    });
+
+    if (!actualChangedKeys.length) {
+      return;
+    }
+
     let shouldSnapshot;
     if (typeof pushToHistory === "boolean") {
       shouldSnapshot = pushToHistory;
-    } else if (normalizedChangedKeys.length) {
-      shouldSnapshot = normalizedChangedKeys.some(key =>
+    } else if (actualChangedKeys.length) {
+      shouldSnapshot = actualChangedKeys.some(key =>
         historyTriggers.includes(key)
       );
     } else {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -916,18 +916,30 @@
     return previousValue === nextValue;
   }
 
+  function restoreSnapshotBlocks(snapshotBlocksRaw) {
+    const currentVersionById = new Map(
+      blocks.map(block => [block.id, block._version || 0])
+    );
+
+    return snapshotBlocksRaw.map(block => {
+      const currentVersion = currentVersionById.get(block.id) || 0;
+      const restoredVersion = Math.max((block._version || 0) + 1, currentVersion + 1);
+      return {
+        ...block,
+        _version: restoredVersion,
+        position: { ...block.position },
+        size: { ...block.size }
+      };
+    });
+  }
+
   async function undo() {
     await ensureCurrentHistorySnapshot();
 
     if (historyIndex > 0) {
       historyIndex--;
       const snapshotState = JSON.parse(history[historyIndex]) || {};
-      const snapshotBlocks = (snapshotState.blocks || []).map(b => ({
-        ...b,
-        _version: (b._version || 0) + 1,
-        position: { ...b.position },
-        size: { ...b.size }
-      }));
+      const snapshotBlocks = restoreSnapshotBlocks(snapshotState.blocks || []);
       const snapshotOrders = ensureModeOrders(
         snapshotBlocks,
         snapshotState.modeOrders
@@ -942,12 +954,7 @@
     if (historyIndex < history.length - 1) {
       historyIndex++;
       const snapshotState = JSON.parse(history[historyIndex]) || {};
-      const snapshotBlocks = (snapshotState.blocks || []).map(b => ({
-        ...b,
-        _version: (b._version || 0) + 1,
-        position: { ...b.position },
-        size: { ...b.size }
-      }));
+      const snapshotBlocks = restoreSnapshotBlocks(snapshotState.blocks || []);
       const snapshotOrders = ensureModeOrders(
         snapshotBlocks,
         snapshotState.modeOrders


### PR DESCRIPTION
### Motivation
- Undo/redo was recording extra snapshots for block updates that did not change any visible state (for example drag-end without movement), causing the first `undo` to appear to do nothing and requiring multiple undos to see a change.

### Description
- Added `updatedBlockValueForKey` and `areHistoryValuesEqual` helpers in `src/App.svelte` to compute and compare prior vs next values for block keys. 
- Updated `updateBlockHandler` to compute `actualChangedKeys` by filtering out keys that do not change, and return early when there are no real changes. 
- Switched snapshot decision logic to use `actualChangedKeys` so history snapshots are only created for real state transitions. 
- Changes live entirely in `src/App.svelte` and preserve existing `pushHistory`/undo/redo behavior while preventing history noise from no-op updates. 

### Testing
- Ran `npm run build` and the Vite build completed successfully (production build passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df2250a5f0832e9cd7bfc496bd0bb7)