### PR TITLE
Remove SimpleNote textarea focus color inversion

### DIFF
--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -315,9 +315,7 @@ textarea {
 }
 
 textarea:focus {
-  color: var(--bg-color);
   outline: none;
-  background: var(--text-color);
 }
 
 textarea::selection {


### PR DESCRIPTION
### Motivation
- Stop inverting textarea foreground/background colors when a SimpleNote block is focused so the note's theme remains consistent and readable.

### Description
- Delete the color/background swap lines from `textarea:focus` in `src/Modes/SimpleNoteMode.svelte`, leaving `outline: none` to suppress the default focus outline.

### Testing
- Ran `npm run build` which completed successfully and produced production assets; the build emitted a Svelte unused-CSS warning but no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5470edac4832e892dedc46c209a7f)