### PR TITLE
Style Simple Note Mode column slider to follow canvas theme

### DIFF
--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -240,16 +240,49 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  color: #ffffff;
+  color: color-mix(in srgb, var(--canvas-inner-bg, #ffffff) 25%, #ffffff);
   font-weight: 700;
   background: color-mix(in srgb, var(--canvas-outer-bg, #000000) 60%, transparent);
-  border: 1px solid color-mix(in srgb, #ffffff 25%, transparent);
+  border: 1px solid color-mix(in srgb, var(--canvas-inner-bg, #ffffff) 35%, transparent);
   border-radius: 999px;
   padding: 0.4rem 0.75rem;
 }
 
 .simple-toolbar input[type="range"] {
   width: min(220px, 36vw);
+  accent-color: color-mix(in srgb, var(--canvas-inner-bg, #ffffff) 65%, #ffffff);
+  cursor: pointer;
+}
+
+.simple-toolbar input[type="range"]::-webkit-slider-runnable-track {
+  height: 0.35rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--canvas-inner-bg, #ffffff) 25%, transparent);
+}
+
+.simple-toolbar input[type="range"]::-moz-range-track {
+  height: 0.35rem;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--canvas-inner-bg, #ffffff) 25%, transparent);
+}
+
+.simple-toolbar input[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 0.9rem;
+  height: 0.9rem;
+  margin-top: -0.275rem;
+  border-radius: 50%;
+  border: 2px solid color-mix(in srgb, var(--canvas-outer-bg, #000000) 70%, #ffffff);
+  background: color-mix(in srgb, var(--canvas-inner-bg, #ffffff) 70%, #ffffff);
+}
+
+.simple-toolbar input[type="range"]::-moz-range-thumb {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  border: 2px solid color-mix(in srgb, var(--canvas-outer-bg, #000000) 70%, #ffffff);
+  background: color-mix(in srgb, var(--canvas-inner-bg, #ffffff) 70%, #ffffff);
 }
 
 .simple-toolbar-value {

--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -14,7 +14,47 @@
   };
 
   $: canvasTheme = { ...defaultCanvasColors, ...(canvasColors || {}) };
-  $: canvasCssVars = `--canvas-outer-bg: ${canvasTheme.outerBg}; --canvas-inner-bg: ${canvasTheme.innerBg};`;
+  $: modeTextColor = getReadableTextColor(canvasTheme.innerBg);
+  $: canvasCssVars = `--canvas-outer-bg: ${canvasTheme.outerBg}; --canvas-inner-bg: ${canvasTheme.innerBg}; --mode-text-color: ${modeTextColor};`;
+
+  function getReadableTextColor(color) {
+    if (!color) return '#f5f5f5';
+    const parsed = parseColor(color);
+    if (!parsed) return '#f5f5f5';
+    const [r, g, b] = parsed;
+    const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+    return luminance > 0.6 ? '#121212' : '#f5f5f5';
+  }
+
+  function parseColor(color) {
+    const trimmed = color.trim();
+    if (trimmed.startsWith('#')) {
+      const hex = trimmed.slice(1);
+      if (hex.length === 3) {
+        return [
+          parseInt(hex[0] + hex[0], 16),
+          parseInt(hex[1] + hex[1], 16),
+          parseInt(hex[2] + hex[2], 16)
+        ];
+      }
+      if (hex.length === 6) {
+        return [
+          parseInt(hex.slice(0, 2), 16),
+          parseInt(hex.slice(2, 4), 16),
+          parseInt(hex.slice(4, 6), 16)
+        ];
+      }
+    }
+    const rgbMatch = trimmed.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/i);
+    if (rgbMatch) {
+      return [
+        Number(rgbMatch[1]),
+        Number(rgbMatch[2]),
+        Number(rgbMatch[3])
+      ];
+    }
+    return null;
+  }
 
   function deleteBlock(id) {
     dispatch('delete', { id });
@@ -240,30 +280,30 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  color: color-mix(in srgb, var(--canvas-inner-bg, #ffffff) 25%, #ffffff);
+  color: var(--mode-text-color, #f5f5f5);
   font-weight: 700;
-  background: color-mix(in srgb, var(--canvas-outer-bg, #000000) 60%, transparent);
-  border: 1px solid color-mix(in srgb, var(--canvas-inner-bg, #ffffff) 35%, transparent);
+  background: var(--canvas-outer-bg, #000000);
+  border: 1px solid var(--mode-text-color, #f5f5f5);
   border-radius: 999px;
   padding: 0.4rem 0.75rem;
 }
 
 .simple-toolbar input[type="range"] {
   width: min(220px, 36vw);
-  accent-color: color-mix(in srgb, var(--canvas-inner-bg, #ffffff) 65%, #ffffff);
+  accent-color: var(--mode-text-color, #f5f5f5);
   cursor: pointer;
 }
 
 .simple-toolbar input[type="range"]::-webkit-slider-runnable-track {
   height: 0.35rem;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--canvas-inner-bg, #ffffff) 25%, transparent);
+  background: var(--canvas-inner-bg, #000000);
 }
 
 .simple-toolbar input[type="range"]::-moz-range-track {
   height: 0.35rem;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--canvas-inner-bg, #ffffff) 25%, transparent);
+  background: var(--canvas-inner-bg, #000000);
 }
 
 .simple-toolbar input[type="range"]::-webkit-slider-thumb {
@@ -273,16 +313,16 @@
   height: 0.9rem;
   margin-top: -0.275rem;
   border-radius: 50%;
-  border: 2px solid color-mix(in srgb, var(--canvas-outer-bg, #000000) 70%, #ffffff);
-  background: color-mix(in srgb, var(--canvas-inner-bg, #ffffff) 70%, #ffffff);
+  border: 2px solid var(--canvas-outer-bg, #000000);
+  background: var(--mode-text-color, #f5f5f5);
 }
 
 .simple-toolbar input[type="range"]::-moz-range-thumb {
   width: 0.9rem;
   height: 0.9rem;
   border-radius: 50%;
-  border: 2px solid color-mix(in srgb, var(--canvas-outer-bg, #000000) 70%, #ffffff);
-  background: color-mix(in srgb, var(--canvas-inner-bg, #ffffff) 70%, #ffffff);
+  border: 2px solid var(--canvas-outer-bg, #000000);
+  background: var(--mode-text-color, #f5f5f5);
 }
 
 .simple-toolbar-value {


### PR DESCRIPTION
### Motivation
- Make the desktop Simple Note Mode column-count scroller visually follow the active canvas theme so the toolbar matches the rest of the canvas UI.
- Improve contrast and consistency by deriving label, border, track and thumb colors from existing canvas CSS variables rather than hard-coded white.

### Description
- Updated `src/Modes/SimpleNoteMode.svelte` to replace hard-coded label and border colors with `color-mix(...)` values based on `--canvas-inner-bg` and `--canvas-outer-bg` CSS variables.
- Added themed styling for the range input including `accent-color` and explicit track/thumb rules for WebKit and Firefox (`::-webkit-slider-runnable-track`, `::-webkit-slider-thumb`, `::-moz-range-track`, `::-moz-range-thumb`) and set `cursor: pointer`.
- Change targets the desktop toolbar slider only (toolbar is hidden under `1024px`), leaving mobile behavior unchanged.

### Testing
- Ran the production build with `npm run build`, which completed successfully.
- The build emitted non-fatal warnings about an unused CSS selector and large chunk sizes, but the process finished without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54928a76c832eb8c443ff60f8f09f)