### PR TITLE
Match Simple Note column slider styling to left-control theme

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1760,6 +1760,7 @@
       modeLabels={MODE_LABELS}
       bind:canvasRef
       canvasColors={canvasTheme}
+      leftControlColors={leftTheme}
       on:update={updateBlockHandler}
       on:delete={deleteBlockHandler}
       on:focusToggle={handleFocusToggle}

--- a/src/Modes/ModeSwitcher.svelte
+++ b/src/Modes/ModeSwitcher.svelte
@@ -15,6 +15,7 @@
   export let onTouchEnd;
   export let focusedBlockId;
   export let canvasColors = {};
+  export let leftControlColors = {};
   export let modeLabels = {};
   export let simpleNoteColumnCount = 2;
 
@@ -72,6 +73,7 @@
       columnCount={simpleNoteColumnCount}
       bind:canvasRef
       {canvasColors}
+      {leftControlColors}
       on:touchstart={onTouchStart}
       on:touchmove={onTouchMove}
       on:touchend={onTouchEnd}

--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -4,6 +4,7 @@
   export let blocks = [];
   export let focusedBlockId = null;
   export let canvasColors = {};
+  export let leftControlColors = {};
   export let canvasRef;
   export let columnCount = 2;
   const dispatch = createEventDispatcher();
@@ -12,10 +13,15 @@
     outerBg: '#000000',
     innerBg: '#000000'
   };
+  const defaultLeftControlColors = {
+    textColor: '#f5f5f5',
+    buttonBg: '#121212'
+  };
 
   $: canvasTheme = { ...defaultCanvasColors, ...(canvasColors || {}) };
+  $: leftTheme = { ...defaultLeftControlColors, ...(leftControlColors || {}) };
   $: modeTextColor = getReadableTextColor(canvasTheme.innerBg);
-  $: canvasCssVars = `--canvas-outer-bg: ${canvasTheme.outerBg}; --canvas-inner-bg: ${canvasTheme.innerBg}; --mode-text-color: ${modeTextColor};`;
+  $: canvasCssVars = `--canvas-outer-bg: ${canvasTheme.outerBg}; --canvas-inner-bg: ${canvasTheme.innerBg}; --mode-text-color: ${modeTextColor}; --left-text-color: ${leftTheme.textColor}; --left-button-bg: ${leftTheme.buttonBg};`;
 
   function getReadableTextColor(color) {
     if (!color) return '#f5f5f5';
@@ -280,30 +286,30 @@
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  color: var(--mode-text-color, #f5f5f5);
+  color: var(--left-text-color, var(--mode-text-color, #f5f5f5));
   font-weight: 700;
-  background: var(--canvas-outer-bg, #000000);
-  border: 1px solid var(--mode-text-color, #f5f5f5);
+  background: var(--left-button-bg, var(--canvas-outer-bg, #000000));
+  border: 1px solid var(--left-text-color, var(--mode-text-color, #f5f5f5));
   border-radius: 999px;
   padding: 0.4rem 0.75rem;
 }
 
 .simple-toolbar input[type="range"] {
   width: min(220px, 36vw);
-  accent-color: var(--mode-text-color, #f5f5f5);
+  accent-color: var(--left-text-color, var(--mode-text-color, #f5f5f5));
   cursor: pointer;
 }
 
 .simple-toolbar input[type="range"]::-webkit-slider-runnable-track {
   height: 0.35rem;
   border-radius: 999px;
-  background: var(--canvas-inner-bg, #000000);
+  background: var(--left-button-bg, var(--canvas-inner-bg, #000000));
 }
 
 .simple-toolbar input[type="range"]::-moz-range-track {
   height: 0.35rem;
   border-radius: 999px;
-  background: var(--canvas-inner-bg, #000000);
+  background: var(--left-button-bg, var(--canvas-inner-bg, #000000));
 }
 
 .simple-toolbar input[type="range"]::-webkit-slider-thumb {
@@ -313,16 +319,16 @@
   height: 0.9rem;
   margin-top: -0.275rem;
   border-radius: 50%;
-  border: 2px solid var(--canvas-outer-bg, #000000);
-  background: var(--mode-text-color, #f5f5f5);
+  border: 2px solid var(--left-button-bg, var(--canvas-outer-bg, #000000));
+  background: var(--left-text-color, var(--mode-text-color, #f5f5f5));
 }
 
 .simple-toolbar input[type="range"]::-moz-range-thumb {
   width: 0.9rem;
   height: 0.9rem;
   border-radius: 50%;
-  border: 2px solid var(--canvas-outer-bg, #000000);
-  background: var(--mode-text-color, #f5f5f5);
+  border: 2px solid var(--left-button-bg, var(--canvas-outer-bg, #000000));
+  background: var(--left-text-color, var(--mode-text-color, #f5f5f5));
 }
 
 .simple-toolbar-value {


### PR DESCRIPTION
### Motivation
- Make the column-count control in Simple Note Mode use the same left-controls theme colors instead of mixing computed colors, so the scroller/label/lines/text follow the left control styling consistently.

### Description
- Add a `leftControlColors` prop to `SimpleNoteMode` and `ModeSwitcher`, and thread `leftTheme` from `App` into the simple mode via `ModeSwitcher` using `leftControlColors`.
- Introduce `defaultLeftControlColors` and compute `leftTheme`, then expose CSS variables `--left-text-color` and `--left-button-bg` in `SimpleNoteMode` (`canvasCssVars`).
- Update the simple-mode column toolbar CSS so the label color, slider accent, slider track, and slider thumb use `--left-text-color` and `--left-button-bg` (remove mixed color usage for that control path).
- Files modified: `src/Modes/SimpleNoteMode.svelte`, `src/Modes/ModeSwitcher.svelte`, and `src/App.svelte`.

### Testing
- Ran the production build with `npm run build`, which completed successfully.
- The build emitted a single Svelte unused CSS selector warning but finished with no errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e54e909030832eb6ec609cc0607508)