### PR TITLE
Move Simple Note column slider into left controls

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1699,6 +1699,7 @@
     <LeftControls
       bind:currentSaveName
       {mode}
+      {simpleNoteColumnCount}
       modeLabels={MODE_LABELS}
       {blocks}
       {savedList}
@@ -1717,6 +1718,7 @@
       on:redo={redo}
       on:moveUp={moveFocusedBlockUp}
       on:moveDown={moveFocusedBlockDown}
+      on:modeSettingChange={handleModeSettingChange}
     />
     <div class="right-controls">
       <RightControls

--- a/src/Modes/ModeSwitcher.svelte
+++ b/src/Modes/ModeSwitcher.svelte
@@ -35,10 +35,6 @@
     dispatch('focusToggle', event.detail);
   }
 
-  function modeSettingChangeHandler(event) {
-    dispatch('modeSettingChange', event.detail);
-  }
-
   function updateWidth() {
     width = window.innerWidth;
   }
@@ -80,7 +76,6 @@
       on:update={updateBlockHandler}
       on:delete={deleteBlockHandler}
       on:focusToggle={focusToggleHandler}
-      on:columnCountChange={modeSettingChangeHandler}
     />
 
   {:else if mode === 'habit'}

--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -219,14 +219,6 @@
     blocks.filter((_, blockIndex) => blockIndex % normalizedColumnCount === columnIndex)
   );
 
-  function handleColumnGaugeInput(event) {
-    const next = Math.max(1, Number.parseInt(event.currentTarget.value, 10) || 1);
-    dispatch('columnCountChange', { columnCount: next });
-  }
-  
-
-
-
   // Resize all textareas when component mounts
   onMount(() => {
     let rafId;
@@ -271,69 +263,6 @@
   margin: 0;
   min-width: 0;
   box-sizing: border-box;
-}
-
-.simple-toolbar {
-  grid-column: 1 / -1;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 0.75rem;
-  padding: 0 0.25rem;
-}
-
-.simple-toolbar label {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  color: var(--left-text-color, var(--mode-text-color, #f5f5f5));
-  font-weight: 700;
-  background: var(--left-button-bg, var(--canvas-outer-bg, #000000));
-  border: 1px solid var(--left-text-color, var(--mode-text-color, #f5f5f5));
-  border-radius: 999px;
-  padding: 0.4rem 0.75rem;
-}
-
-.simple-toolbar input[type="range"] {
-  width: min(220px, 36vw);
-  accent-color: var(--left-text-color, var(--mode-text-color, #f5f5f5));
-  cursor: pointer;
-}
-
-.simple-toolbar input[type="range"]::-webkit-slider-runnable-track {
-  height: 0.35rem;
-  border-radius: 999px;
-  background: var(--left-text-color, var(--mode-text-color, #f5f5f5));
-}
-
-.simple-toolbar input[type="range"]::-moz-range-track {
-  height: 0.35rem;
-  border-radius: 999px;
-  background: var(--left-text-color, var(--mode-text-color, #f5f5f5));
-}
-
-.simple-toolbar input[type="range"]::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 0.9rem;
-  height: 0.9rem;
-  margin-top: -0.275rem;
-  border-radius: 50%;
-  border: 2px solid var(--left-button-bg, var(--canvas-outer-bg, #000000));
-  background: var(--left-text-color, var(--mode-text-color, #f5f5f5));
-}
-
-.simple-toolbar input[type="range"]::-moz-range-thumb {
-  width: 0.9rem;
-  height: 0.9rem;
-  border-radius: 50%;
-  border: 2px solid var(--left-button-bg, var(--canvas-outer-bg, #000000));
-  background: var(--left-text-color, var(--mode-text-color, #f5f5f5));
-}
-
-.simple-toolbar-value {
-  min-width: 1.25rem;
-  text-align: center;
 }
 
 .simple-column {
@@ -508,9 +437,6 @@ li {
     padding: 8px;
   }
 
-  .simple-toolbar {
-    display: none;
-  }
 }
 
 </style>
@@ -524,20 +450,6 @@ li {
 
 
 <div class="simple-wrapper" bind:this={canvasRef} style={`${canvasCssVars} --simple-note-columns: ${normalizedColumnCount};`}>
-  <div class="simple-toolbar">
-    <label>
-      Columns
-      <input
-        type="range"
-        min="1"
-        max="6"
-        step="1"
-        value={normalizedColumnCount}
-        on:input={handleColumnGaugeInput}
-      />
-      <span class="simple-toolbar-value">{normalizedColumnCount}</span>
-    </label>
-  </div>
   {#each renderColumns as column}
     <div class="simple-column">
       {#each column as block (blockKey(block))}

--- a/src/advanced-param/LeftControls.svelte
+++ b/src/advanced-param/LeftControls.svelte
@@ -5,6 +5,7 @@
   export let modeLabels = {};
   export let currentSaveName;
   export let focusedBlockId = null;
+  export let simpleNoteColumnCount = 2;
   export let colors = {};
   export let birthdayModeUnlocked = false;
   export let birthdayUnlockMessage = '';
@@ -65,6 +66,7 @@
 
   $: isSingleNoteMode = mode === "single";
   $: isTaskMode = mode === "task";
+  $: isSimpleNoteMode = mode === "simple";
 
   function addBlock(type) {
     if (isSingleNoteMode && type !== "text" && type !== "cleantext") return;
@@ -122,6 +124,11 @@
   function moveDown() {
     if (!focusedBlockId) return;
     dispatch("moveDown");
+  }
+
+  function handleSimpleColumnInput(event) {
+    const next = Math.max(1, Number.parseInt(event.currentTarget.value, 10) || 1);
+    dispatch("modeSettingChange", { columnCount: next });
   }
 
   function checkWidth() {
@@ -353,6 +360,31 @@ onMount(() => {
     display: none;
   }
 
+  .simple-columns-control {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--left-text-color, #ffffff);
+    font-weight: 700;
+    background: var(--left-button-bg, #333333);
+    border: 1px solid var(--left-border-color, #444444);
+    border-radius: 6px;
+    padding: 8px 10px;
+    min-height: 42px;
+    box-sizing: border-box;
+  }
+
+  .simple-columns-control input[type="range"] {
+    width: min(150px, 18vw);
+    accent-color: var(--left-text-color, #ffffff);
+    cursor: pointer;
+  }
+
+  .simple-columns-value {
+    min-width: 1.25rem;
+    text-align: center;
+  }
+
   @media (max-width: 1024px) {
     .left-controls {
       display: none;
@@ -416,6 +448,10 @@ onMount(() => {
       grid-template-columns: 1fr;
       gap: 3px;
       width: 100%;
+    }
+
+    .simple-columns-control {
+      display: none;
     }
 
     .mode-ladder,
@@ -606,6 +642,20 @@ onMount(() => {
     />
     <input bind:value={currentSaveName} placeholder="File name" />
     <button on:click={save}>💾 Save</button>
+    {#if isSimpleNoteMode}
+      <label class="simple-columns-control mobile-only">
+        Columns
+        <input
+          type="range"
+          min="1"
+          max="6"
+          step="1"
+          value={simpleNoteColumnCount}
+          on:input={handleSimpleColumnInput}
+        />
+        <span class="simple-columns-value">{simpleNoteColumnCount}</span>
+      </label>
+    {/if}
 
   </div>
 </div>


### PR DESCRIPTION
### Motivation
- On desktop Simple Note mode the column-count control should live in the left controls panel (after the Save button) instead of the in-canvas toolbar. 
- Keep mode settings persisted via existing mode settings plumbing so column changes are saved alongside other mode settings.

### Description
- Added a `simpleNoteColumnCount` prop to `LeftControls.svelte` and a `handleSimpleColumnInput` that dispatches `modeSettingChange` with the new `columnCount`.
- Moved the Simple Note columns slider UI into `LeftControls.svelte` (rendered after the Save button when Simple Note mode is active) and added styles for the control.
- Removed the in-canvas slider UI and its event handler from `src/Modes/SimpleNoteMode.svelte` and cleaned up the associated CSS.
- Wired `App.svelte` to pass `simpleNoteColumnCount` into `LeftControls` and listen for `on:modeSettingChange={handleModeSettingChange}`, and removed the outdated forwarding in `ModeSwitcher.svelte`.

### Testing
- Ran the production build with `npm run build` and the build completed successfully (warnings only about bundle size and one unused CSS selector).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e84a9a14e0832eb7b729eca3330123)