### PR TITLE
Add New File button above saved files in right controls

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1111,6 +1111,37 @@
     }
   }
 
+  async function createNewFile() {
+    const proposedName = window.prompt('Enter a name for the new file:');
+    if (proposedName === null) {
+      return;
+    }
+
+    const trimmedName = proposedName.trim();
+    if (!trimmedName) {
+      alert('File name cannot be empty.');
+      return;
+    }
+
+    if (savedList.includes(trimmedName)) {
+      const shouldOverwrite = window.confirm(`"${trimmedName}" already exists. Overwrite it with a blank file?`);
+      if (!shouldOverwrite) {
+        return;
+      }
+    }
+
+    currentSaveName = trimmedName;
+    persistLastSaveName(trimmedName);
+    blocks = [];
+    focusedBlockId = null;
+    modeOrders = ensureModeOrders(blocks, modeOrders);
+    history = [];
+    historyIndex = -1;
+    await pushHistory(blocks, modeOrders);
+    hasUnsnapshottedChanges = false;
+    savedList = await listSavedBlocks();
+  }
+
   async function clear() {
     blocks = [];
     focusedBlockId = null;
@@ -1725,6 +1756,7 @@
         {savedList}
         {load}
         {deleteSave}
+        {createNewFile}
         {controlColors}
         themes={availableThemes}
         {selectedThemeId}

--- a/src/advanced-param/RightControls.svelte
+++ b/src/advanced-param/RightControls.svelte
@@ -2,6 +2,7 @@
   export let savedList = [];
   export let load;
   export let deleteSave;
+  export let createNewFile;
   export let controlColors = {};
   export let themes = [];
   export let selectedThemeId = 'default-dark';
@@ -105,6 +106,13 @@
   function handleSelect(name) {
     load(name);
     // Auto-close dropdown only on mobile
+    if (!pc) {
+      isOpen = false;
+    }
+  }
+
+  function handleCreateNewFile() {
+    createNewFile?.();
     if (!pc) {
       isOpen = false;
     }
@@ -316,6 +324,9 @@
       <div class="controls-scroll">
         <div class="tab-section">
           <h4>📂 Saved Files</h4>
+          <button class="create-theme-btn" type="button" on:click={handleCreateNewFile}>
+            ➕ New File
+          </button>
           {#if savedList.length}
             <ul>
               {#each savedList as name}


### PR DESCRIPTION
### Motivation
- Provide a quick way for users to create a new blank save directly from the right-side Settings panel without going through the left controls.
- Ensure the new action integrates with existing save/load/persistence flows and behaves consistently on mobile by closing the right panel after activation.

### Description
- Added a `➕ New File` button above the saved files list in `src/advanced-param/RightControls.svelte` and implemented a local `handleCreateNewFile` handler that closes the panel on mobile.
- Exposed a new `createNewFile` prop on `RightControls` and wired it from `App.svelte` when rendering the component.
- Implemented `createNewFile` in `src/App.svelte` to prompt for a file name, validate non-empty input, confirm overwrite if the name already exists, reset the workspace to a blank state, persist the blank save via the existing history/save flow, and refresh `savedList`.
- Kept mobile behavior consistent by auto-closing the right controls dropdown after creating a new file.

### Testing
- Ran a production build with `npm run build`, which completed successfully with only unrelated non-blocking warnings.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8513ec6ac832eaebf6a61c31a6a84)