### PR TITLE
Keep mobile controls anchored during scroll

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1645,10 +1645,12 @@
   .app {
   display: flex;
   flex-direction: column;
-  height: 100vh; /* full app height */
+  height: 100dvh; /* full app height (stable on mobile browsers) */
+  overflow: hidden;
 }
 .controls {
   flex: 0 0 auto;  /* only as tall as needed */
+  position: sticky;
   top: 0;
   left: 0;
   right: 0;
@@ -1660,6 +1662,7 @@
   padding: 8px 10px;
   background: var(--controls-bg, #111);
   border-bottom: 1px solid var(--controls-border, #333);
+  overscroll-behavior: contain;
 }
 
 .right-controls {

--- a/src/app.css
+++ b/src/app.css
@@ -50,9 +50,11 @@ body {
   display: flex;
   align-items: center;     /* vertical */
   justify-content: center; /* horizontal */
-  height: 100vh;           /* exact viewport height */
+  height: 100dvh;          /* exact viewport height */
   margin: 0;
   background: #161616;
+  overflow: hidden;
+  overscroll-behavior: none;
 }
 
 
@@ -71,6 +73,7 @@ h1 {
   height: 100%;   /* fill viewport */
   width: 100%;
   background: #000000;
+  overflow: hidden;
 }
 
 


### PR DESCRIPTION
### Motivation
- Mobile browsers were allowing the top controls to be dragged/hidden during page scroll, causing the controls to disappear unexpectedly while the PC behavior remained stable.

### Description
- Use `100dvh` instead of `100vh` to make the app viewport height stable on mobile by updating `src/App.svelte` and `src/app.css`.
- Prevent page overscroll and root scrolling by adding `overflow: hidden` to `.app`, `body`, and `#app`, and set `overscroll-behavior: none` on `body` in `src/app.css`.
- Anchor the controls bar by adding `position: sticky; top: 0;` and constrain its overscroll with `overscroll-behavior: contain` in `src/App.svelte`.
- Changes were applied to `src/App.svelte` and `src/app.css`.

### Testing
- Ran `npm run build`, which completed successfully; the build emitted non-fatal warnings about chunk size and an unrelated unused CSS selector.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f12252a404832e968ab0471fdc6eeb)