### PR TITLE
Add Cloud Storage uploads for block attachments and update Firebase sync docs

### DIFF
--- a/FIREBASE_SYNC.md
+++ b/FIREBASE_SYNC.md
@@ -10,7 +10,7 @@ VITE_FIREBASE_AUTH_DOMAIN=...
 VITE_FIREBASE_PROJECT_ID=...
 VITE_FIREBASE_APP_ID=...
 VITE_FIREBASE_DB_URL=https://YOUR_DB.firebaseio.com
-VITE_FIREBASE_STORAGE_BUCKET=YOUR_PROJECT_ID.appspot.com
+VITE_FIREBASE_STORAGE_BUCKET=YOUR_BUCKET (often YOUR_PROJECT_ID.firebasestorage.app or YOUR_PROJECT_ID.appspot.com)
 VITE_FIREBASE_SYNC_NAMESPACE=default
 ```
 
@@ -61,17 +61,15 @@ Do not use open/public read or write rules.
 
 - RTDB: `/sync/{namespace}/users/{uid}/files/{fileId}`
 - RTDB: `/sync/{namespace}/users/{uid}/index/{fileId}`
-- Storage: `users/{uid}/attachments/{attachmentId}.{ext}`
+- Storage: `users/{uid}/attachments/{fileId}/{blockId}/{field}/{generatedName}.{ext}`
 
 Users only access their own `{uid}` subtree.
 
 ## Attachment behavior
 
 - On save, inline base64 media is uploaded to Cloud Storage.
-- The JSON written to RTDB stores a lightweight reference only:
-  `{ type: "storage", attachmentId, storagePath, contentType, size }`
-- `downloadURL` is never persisted to RTDB.
-- On load, storage refs are resolved at runtime via `getDownloadURL` before rendering.
+- The JSON written to RTDB stores only the Storage download URL string in the media field.
+- Media bytes are not stored in RTDB.
 - Existing inline/base64 media gets migrated during the next signed-in save.
 
 ## Billing note

--- a/src/firebaseClient.js
+++ b/src/firebaseClient.js
@@ -11,6 +11,7 @@ const REQUIRED_FIREBASE_KEYS = [
 ];
 
 const FIREBASE_SDK_VERSION = '11.7.0';
+const ATTACHMENT_FIELDS = ['src', 'content', 'trackUrl'];
 
 let firebaseModulesPromise;
 let firebaseContextPromise;
@@ -20,8 +21,9 @@ function loadFirebaseModules() {
     firebaseModulesPromise = Promise.all([
       import(/* @vite-ignore */ `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-app.js`),
       import(/* @vite-ignore */ `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-auth.js`),
-      import(/* @vite-ignore */ `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-database.js`)
-    ]).then(([app, auth, database]) => ({ app, auth, database }));
+      import(/* @vite-ignore */ `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-database.js`),
+      import(/* @vite-ignore */ `https://www.gstatic.com/firebasejs/${FIREBASE_SDK_VERSION}/firebase-storage.js`)
+    ]).then(([app, auth, database, storage]) => ({ app, auth, database, storage }));
   }
   return firebaseModulesPromise;
 }
@@ -29,17 +31,64 @@ function loadFirebaseModules() {
 async function getFirebaseContext() {
   if (!isFirebaseConfigured()) return null;
   if (!firebaseContextPromise) {
-    firebaseContextPromise = loadFirebaseModules().then(({ app, auth, database }) => {
+    firebaseContextPromise = loadFirebaseModules().then(({ app, auth, database, storage }) => {
       const firebaseApp = app.getApps().length
         ? app.getApp()
         : app.initializeApp(firebaseConfig);
       const firebaseAuth = auth.getAuth(firebaseApp);
       auth.setPersistence(firebaseAuth, auth.browserLocalPersistence).catch(() => {});
       const firebaseDb = database.getDatabase(firebaseApp);
-      return { app: firebaseApp, auth: firebaseAuth, db: firebaseDb, authApi: auth, dbApi: database };
+      const firebaseStorage = storage.getStorage(firebaseApp);
+      return { app: firebaseApp, auth: firebaseAuth, db: firebaseDb, storage: firebaseStorage, authApi: auth, dbApi: database, storageApi: storage };
     });
   }
   return firebaseContextPromise;
+}
+
+function inferExtensionFromMime(mime = '') {
+  const normalized = String(mime).toLowerCase();
+  if (normalized.includes('jpeg')) return 'jpg';
+  if (normalized.includes('png')) return 'png';
+  if (normalized.includes('gif')) return 'gif';
+  if (normalized.includes('webp')) return 'webp';
+  if (normalized.includes('svg')) return 'svg';
+  if (normalized.includes('mp4')) return 'mp4';
+  if (normalized.includes('webm')) return 'webm';
+  if (normalized.includes('ogg')) return 'ogg';
+  if (normalized.includes('mpeg')) return 'mp3';
+  return 'bin';
+}
+
+async function uploadBlockAttachments(fileId, payload, ctx, uid) {
+  if (!Array.isArray(payload?.blocks)) return payload;
+
+  const blocks = await Promise.all(payload.blocks.map(async (block, index) => {
+    const next = { ...block };
+
+    for (const field of ATTACHMENT_FIELDS) {
+      const value = next[field];
+      if (typeof value !== 'string' || !value.startsWith('data:')) continue;
+
+      const uploadedUrl = await uploadAttachmentFromDataUrl(value, {
+        fileId,
+        blockId: block?.id || `block-${index + 1}`,
+        field,
+        uid,
+        ctx
+      });
+
+      if (uploadedUrl) {
+        next[field] = uploadedUrl;
+      }
+    }
+
+    return next;
+  }));
+
+  return {
+    ...payload,
+    blocks
+  };
 }
 
 function normalizeNamespace() {
@@ -49,6 +98,10 @@ function normalizeNamespace() {
 function getUserPath(uid, suffix = '') {
   const ns = normalizeNamespace();
   return `sync/${ns}/users/${uid}/${suffix}`.replace(/\/$/, '');
+}
+
+function getStorageUserPath(uid, suffix = '') {
+  return `users/${uid}/${suffix}`.replace(/\/$/, '');
 }
 
 function requireUser(user) {
@@ -132,11 +185,12 @@ export async function saveRemoteFile(fileId, payload) {
   if (!isFirebaseConfigured()) return null;
   const ctx = await getFirebaseContext();
   const user = requireUser(ctx.auth.currentUser);
+  const payloadWithRemoteAttachments = await uploadBlockAttachments(fileId, payload, ctx, user.uid);
   const updatedAt = payload?.updatedAt || Date.now();
 
   await ctx.dbApi.set(
     ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `files/${fileId}`)),
-    { ...payload, updatedAt }
+    { ...payloadWithRemoteAttachments, updatedAt }
   );
 
   await ctx.dbApi.set(
@@ -144,7 +198,7 @@ export async function saveRemoteFile(fileId, payload) {
     {
       fileId,
       updatedAt,
-      blockCount: Array.isArray(payload?.blocks) ? payload.blocks.length : 0
+      blockCount: Array.isArray(payloadWithRemoteAttachments?.blocks) ? payloadWithRemoteAttachments.blocks.length : 0
     }
   );
 
@@ -164,8 +218,30 @@ export async function deleteRemoteFile(fileId) {
   return { fileId };
 }
 
-export async function uploadAttachmentFromDataUrl() {
-  return null;
+export async function uploadAttachmentFromDataUrl(dataUrl, options = {}) {
+  if (typeof dataUrl !== 'string' || !dataUrl.startsWith('data:')) return null;
+
+  const ctx = options.ctx || await getFirebaseContext();
+  if (!ctx) return null;
+
+  const uid = options.uid || requireUser(ctx.auth.currentUser).uid;
+  const response = await fetch(dataUrl);
+  const blob = await response.blob();
+  const mime = blob.type || 'application/octet-stream';
+  const ext = inferExtensionFromMime(mime);
+  const fileId = String(options.fileId || 'unknown-file');
+  const blockId = String(options.blockId || 'unknown-block');
+  const field = String(options.field || 'attachment');
+  const objectName = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}.${ext}`;
+  const objectPath = `${getStorageUserPath(uid, `attachments/${fileId}/${blockId}/${field}`)}/${objectName}`;
+  const storageRef = ctx.storageApi.ref(ctx.storage, objectPath);
+
+  await ctx.storageApi.uploadBytes(storageRef, blob, {
+    contentType: mime,
+    cacheControl: 'public,max-age=31536000'
+  });
+
+  return await ctx.storageApi.getDownloadURL(storageRef);
 }
 
 export async function resolveAttachmentUrl(value) {


### PR DESCRIPTION
### Motivation

- Enable secure, per-user Cloud Storage for large media by uploading inline/base64 attachments to Storage and storing download URLs in the RTDB.
- Support migrating existing inline media on next signed-in save and avoid persisting media bytes in Realtime Database.

### Description

- Update `FIREBASE_SYNC.md` to document the new Storage object path format and that RTDB now stores the Storage download URL string rather than inline media or a storage metadata object.
- Add Storage SDK imports and initialization in `src/firebaseClient.js` and expose `storage` in the Firebase context via `getFirebaseContext`.
- Introduce `ATTACHMENT_FIELDS`, `getStorageUserPath`, `inferExtensionFromMime`, `uploadBlockAttachments`, and a full implementation of `uploadAttachmentFromDataUrl` to upload data-URLs to Storage and return `getDownloadURL` strings.
- Wire attachment uploading into `saveRemoteFile` to transform `payload.blocks` before writing to RTDB and update the index `blockCount` calculation to use the transformed payload.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f635d5f50c832e8de58dbea6635bf5)