### PR TITLE
Fix canvas block focus flicker by ensuring focus on wrapper clicks

### DIFF
--- a/src/components/EmbedBlock.svelte
+++ b/src/components/EmbedBlock.svelte
@@ -162,7 +162,7 @@
       ensureFocus();
       return;
     }
-    dispatch('focusToggle', { id });
+    ensureFocus();
   }
 
   function handleWrapperKeydown(event) {

--- a/src/components/ImgBlock.svelte
+++ b/src/components/ImgBlock.svelte
@@ -448,7 +448,7 @@ function onResizeEnd() {
   <div class="header" bind:this={headerRef} role="presentation" on:mousedown={onDragStart}
     on:pointerdown={onDragStart} on:touchstart={onDragStart}>
     <div>image</div>
-    <div class="header-controls" on:mousedown|stopPropagation role="presentation">
+    <div class="header-controls" on:mousedown|stopPropagation on:pointerdown|stopPropagation on:touchstart|stopPropagation role="presentation">
 
         <input
           type="color"
@@ -463,7 +463,7 @@ function onResizeEnd() {
           data-focus-guard
         />
 
-      <label title="Change Image" class="media-btn" data-focus-guard>
+      <label title="Change Image" class="media-btn" data-focus-guard on:click|stopPropagation on:pointerdown|stopPropagation on:touchstart|stopPropagation>
         <input type="file" accept="image/*,video/mp4" on:change={onMediaChange} data-focus-guard />
         <span class="emoji" data-focus-guard>⏏</span>
       </label>

--- a/src/components/ImgBlock.svelte
+++ b/src/components/ImgBlock.svelte
@@ -304,7 +304,7 @@ function onResizeEnd() {
       ensureFocus();
       return;
     }
-    dispatch('focusToggle', { id });
+    ensureFocus();
   }
 
   function handleWrapperKeydown(event) {

--- a/src/components/MusicBlock.svelte
+++ b/src/components/MusicBlock.svelte
@@ -171,7 +171,7 @@
       ensureFocus();
       return;
     }
-    dispatch('focusToggle', { id });
+    ensureFocus();
   }
 
   function handleWrapperKeydown(event) {

--- a/src/components/TaskBlock.svelte
+++ b/src/components/TaskBlock.svelte
@@ -177,7 +177,7 @@
       ensureFocus();
       return;
     }
-    dispatch('focusToggle', { id });
+    ensureFocus();
   }
 
   function handleWrapperKeydown(event) {

--- a/src/components/TexteBlock.svelte
+++ b/src/components/TexteBlock.svelte
@@ -171,7 +171,7 @@
       ensureFocus();
       return;
     }
-    dispatch('focusToggle', { id });
+    ensureFocus();
   }
 
   function handleWrapperKeydown(event) {

--- a/src/components/TexteClean.svelte
+++ b/src/components/TexteClean.svelte
@@ -174,7 +174,7 @@
       ensureFocus();
       return;
     }
-    dispatch('focusToggle', { id });
+    ensureFocus();
   }
 
   function handleWrapperKeydown(event) {


### PR DESCRIPTION
### Motivation
- Clicking block wrappers could toggle focus off when a block was already focused, causing a visible blink and making inner controls (e.g. image file input) intermittently unclickable.
- The goal is to make interactions inside a focused block reliably keep the block focused instead of toggling focus state.

### Description
- Replaced the wrapper click behavior in canvas block components so clicks call `ensureFocus()` instead of `dispatch('focusToggle', { id })` to avoid toggling focus off.
- Applied the change to `src/components/ImgBlock.svelte`, `TexteBlock.svelte`, `TexteClean.svelte`, `MusicBlock.svelte`, `EmbedBlock.svelte`, and `TaskBlock.svelte` by updating `handleWrapperClick` to call `ensureFocus()`.
- Kept existing `ensureFocus()` helpers which dispatch `focusToggle` only when the block is not already focused, preserving keyboard/space/enter behavior.

### Testing
- Ran a production build with `npm run build` and the build completed successfully.
- Observed only existing non-blocking Vite warnings (unused CSS selector and large chunk-size warning) which did not affect the build result.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63ac2f2b8832eb3de950f68bebc76)