### PR TITLE
Introduce mode registry and drive left/right controls from mode metadata

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -23,6 +23,7 @@
     normalizeControlColors
   } from './utils/themeDefaults.js';
 
+  import { MODE_DEFINITIONS, MODE_ORDER, getModeDefinition } from "./Modes/modeRegistry.js";
   const BLOCK_THEME_STORAGE_KEY = 'blockTheme';
   const BLOCK_THEME_ID_STORAGE_KEY = 'blockThemeId';
   const CUSTOM_THEMES_STORAGE_KEY = 'customThemes';
@@ -712,15 +713,10 @@
     __default: ['position', 'size', 'bgColor', 'textColor', 'content', 'src', 'trackUrl', 'title']
   };
 
-  const KNOWN_MODES = ["default", "simple", "single", "habit", "task", "birthday"];
-  const MODE_LABELS = {
-    default: "Canvas Mode",
-    simple: "Simple Note Mode",
-    single: "Single Note Mode",
-    habit: "Habit Tracker Mode",
-    task: "Task Mode",
-    birthday: "Birthday Mode"
-  };
+  const KNOWN_MODES = [...MODE_ORDER];
+  const MODE_LABELS = Object.fromEntries(
+    Object.values(MODE_DEFINITIONS).map((definition) => [definition.id, definition.label])
+  );
 
   function applyHistoryTriggers(block) {
     const triggers =
@@ -786,6 +782,8 @@
   let mode = getDefaultModeForViewport();
   let modeSettings = normalizeModeSettings();
   $: simpleNoteColumnCount = modeSettings.simple.columnCount;
+  $: activeModeDefinition = getModeDefinition(mode);
+  $: showRightControls = activeModeDefinition?.showRightControls !== false;
   let blocks = [];
   let modeOrders = {};
   let normalizedModeOrders = ensureModeOrders(blocks, modeOrders);
@@ -1750,6 +1748,7 @@
       on:moveDown={moveFocusedBlockDown}
       on:modeSettingChange={handleModeSettingChange}
     />
+    {#if showRightControls}
     <div class="right-controls">
       <RightControls
         {savedList}
@@ -1772,6 +1771,7 @@
         on:openAdvancedCss={() => (showAdvancedCssPage = true)}
       />
     </div>
+    {/if}
   </div>
 
   {#if deferredLastSaveName}

--- a/src/Modes/modeRegistry.js
+++ b/src/Modes/modeRegistry.js
@@ -1,0 +1,58 @@
+export const MODE_DEFINITIONS = {
+  default: {
+    id: 'default',
+    label: 'Canvas Mode',
+    addBlockTypes: ['text', 'cleantext', 'image', 'music', 'embed'],
+    showRightControls: true
+  },
+  simple: {
+    id: 'simple',
+    label: 'Simple Note Mode',
+    addBlockTypes: ['text', 'cleantext', 'image', 'music', 'embed'],
+    showRightControls: true,
+    settings: { simpleColumns: true }
+  },
+  single: {
+    id: 'single',
+    label: 'Single Note Mode',
+    addBlockTypes: ['text', 'cleantext'],
+    showRightControls: true
+  },
+  habit: {
+    id: 'habit',
+    label: 'Habit Tracker Mode',
+    addBlockTypes: [],
+    showRightControls: false
+  },
+  task: {
+    id: 'task',
+    label: 'Task Mode',
+    addBlockTypes: ['text', 'cleantext', 'image', 'music', 'embed', 'task'],
+    showRightControls: true
+  },
+  birthday: {
+    id: 'birthday',
+    label: 'Birthday Mode',
+    addBlockTypes: [],
+    showRightControls: false,
+    requiresUnlock: true
+  }
+};
+
+export const MODE_ORDER = ['default', 'simple', 'single', 'habit', 'task', 'birthday'];
+
+export function getModeDefinition(mode) {
+  return MODE_DEFINITIONS[mode] || MODE_DEFINITIONS.single;
+}
+
+export function getModeOptions({ birthdayModeUnlocked = false } = {}) {
+  return MODE_ORDER.map((id) => {
+    const def = MODE_DEFINITIONS[id];
+    const locked = def.requiresUnlock && !birthdayModeUnlocked;
+    return {
+      id,
+      label: locked ? `${def.label} 🔒` : def.label,
+      locked
+    };
+  });
+}

--- a/src/advanced-param/LeftControls.svelte
+++ b/src/advanced-param/LeftControls.svelte
@@ -1,5 +1,6 @@
 <script>
   import { createEventDispatcher, onMount } from "svelte";
+  import { getModeDefinition, getModeOptions } from "../Modes/modeRegistry.js";
 
   export let mode;
   export let modeLabels = {};
@@ -30,17 +31,8 @@
   let showAddBlockMenu = false;
   let birthdayPassword = '';
 
-  $: modeOptions = [
-    { id: "default", label: "Canvas Mode" },
-    { id: "simple", label: "Simple Note Mode" },
-    { id: "single", label: "Single Note Mode" },
-    { id: "habit", label: "Habit Tracker Mode" },
-    { id: "task", label: "Task Mode" },
-    {
-      id: "birthday",
-      label: birthdayModeUnlocked ? "Birthday Mode" : "Birthday Mode 🔒"
-    }
-  ];
+  $: modeOptions = getModeOptions({ birthdayModeUnlocked });
+  $: activeModeDefinition = getModeDefinition(mode);
 
   const defaultColors = {
     panelBg: "#111111b0",
@@ -64,12 +56,12 @@
     .join("; ");
 
 
-  $: isSingleNoteMode = mode === "single";
-  $: isTaskMode = mode === "task";
-  $: isSimpleNoteMode = mode === "simple";
+  $: isSimpleNoteMode = Boolean(activeModeDefinition?.settings?.simpleColumns);
+  $: availableAddBlockTypes = activeModeDefinition?.addBlockTypes || [];
+  $: canAddBlock = (type) => availableAddBlockTypes.includes(type);
 
   function addBlock(type) {
-    if (isSingleNoteMode && type !== "text" && type !== "cleantext") return;
+    if (!canAddBlock(type)) return;
     dispatch("addBlock", type);
   }
 
@@ -509,7 +501,7 @@ onMount(() => {
                 on:click={() => selectMode(option.id)}
                 role="option"
                 aria-selected={option.id === mode}
-                disabled={option.id === 'birthday' && !birthdayModeUnlocked}
+                disabled={option.locked}
               >
                 {option.label}
               </button>
@@ -555,7 +547,7 @@ onMount(() => {
               on:click={() => selectMode(option.id)}
               role="option"
               aria-selected={option.id === mode}
-              disabled={option.id === 'birthday' && !birthdayModeUnlocked}
+              disabled={option.locked}
             >
               {option.label}
             </button>
@@ -588,10 +580,10 @@ onMount(() => {
         <div class="add-block-list" bind:this={addBlockMenuDesktopRef} role="listbox">
           <button on:click={() => addBlock("text")}>+ Text</button>
           <button on:click={() => addBlock("cleantext")}>+ Clean Text</button>
-          <button on:click={() => addBlock("image")} disabled={isSingleNoteMode}>+ Image</button>
-          <button on:click={() => addBlock("music")} disabled={isSingleNoteMode}>+ Music</button>
-          <button on:click={() => addBlock("embed")} disabled={isSingleNoteMode}>+ Embed</button>
-          {#if isTaskMode}
+          <button on:click={() => addBlock("image")} disabled={!canAddBlock("image")}>+ Image</button>
+          <button on:click={() => addBlock("music")} disabled={!canAddBlock("music")}>+ Music</button>
+          <button on:click={() => addBlock("embed")} disabled={!canAddBlock("embed")}>+ Embed</button>
+          {#if canAddBlock("task")}
             <button on:click={() => addBlock("task")}>+ Task List</button>
           {/if}
         </div>
@@ -626,10 +618,10 @@ onMount(() => {
     <div class="mobile-block-actions">
       <button on:click={() => addBlock("text")}>+ Text</button>
       <button on:click={() => addBlock("cleantext")}>+ Clean Text</button>
-      <button on:click={() => addBlock("image")} disabled={isSingleNoteMode}>+ Image</button>
-      <button on:click={() => addBlock("music")} disabled={isSingleNoteMode}>+ Music</button>
-      <button on:click={() => addBlock("embed")} disabled={isSingleNoteMode}>+ Embed</button>
-      {#if isTaskMode}
+      <button on:click={() => addBlock("image")} disabled={!canAddBlock("image")}>+ Image</button>
+      <button on:click={() => addBlock("music")} disabled={!canAddBlock("music")}>+ Music</button>
+      <button on:click={() => addBlock("embed")} disabled={!canAddBlock("embed")}>+ Embed</button>
+      {#if canAddBlock("task")}
         <button on:click={() => addBlock("task")}>+ Task List</button>
       {/if}
     </div>


### PR DESCRIPTION
### Motivation
- Make modes easy to add or remove by centralizing mode metadata and UI behavior in one place so controls naturally appear or disappear with modes.
- Ensure per-mode capabilities (addable block types, unlock rules, control visibility, and settings) live with the mode definition so removing a mode leaves no latent UI behavior.

### Description
- Add `src/Modes/modeRegistry.js` which declares `MODE_DEFINITIONS`, `MODE_ORDER`, `getModeDefinition`, and `getModeOptions` to act as a single source of truth for mode labels, allowed block types, unlock flags, settings, and whether right controls should be shown.
- Update `src/advanced-param/LeftControls.svelte` to consume the registry for `modeOptions`, compute the active mode definition, and gate add-block buttons via `availableAddBlockTypes`/`canAddBlock` instead of spread conditionals.
- Update `src/App.svelte` to derive `MODE_LABELS` and known modes from the registry and to conditionally render the right-side controls with a reactive `showRightControls` driven by the active mode definition.

### Testing
- Ran `npm run build` and it completed successfully (production build succeeded despite a11y/CSS warnings emitted by the Svelte compiler).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63dd75f50832e9135d177b4c0ac35)