### PR TITLE
Fix header control buttons not clickable on blocks

### DIFF
--- a/src/components/EmbedBlock.svelte
+++ b/src/components/EmbedBlock.svelte
@@ -293,7 +293,7 @@
     role="presentation"
   >
     <span>{title}</span>
-    <div class="header-controls" on:mousedown|stopPropagation role="presentation">
+    <div class="header-controls" on:mousedown|stopPropagation on:pointerdown|stopPropagation on:touchstart|stopPropagation role="presentation">
       <button
         on:click={() => { ensureFocus(); showSettings = !showSettings; }}
         class="gear-btn"

--- a/src/components/MusicBlock.svelte
+++ b/src/components/MusicBlock.svelte
@@ -307,7 +307,7 @@
     role="presentation"
   >
     <span>{title}</span>
-    <div class="header-controls" on:mousedown|stopPropagation role="presentation">
+    <div class="header-controls" on:mousedown|stopPropagation on:pointerdown|stopPropagation on:touchstart|stopPropagation role="presentation">
       <button
         on:click={() => { ensureFocus(); showSettings = !showSettings; }}
         class="gear-btn"

--- a/src/components/TaskBlock.svelte
+++ b/src/components/TaskBlock.svelte
@@ -407,7 +407,7 @@
     role="presentation"
   >
     <div class="header-title">{title || 'Task List'}</div>
-    <div class="header-controls" on:mousedown|stopPropagation on:pointerdown|stopPropagation role="presentation">
+    <div class="header-controls" on:mousedown|stopPropagation on:pointerdown|stopPropagation on:touchstart|stopPropagation role="presentation">
       <label title="Background Color">
         <input
           type="color"

--- a/src/components/TexteBlock.svelte
+++ b/src/components/TexteBlock.svelte
@@ -302,7 +302,7 @@
     role="presentation"
   >
     <div>text</div>
-    <div class="header-controls" on:mousedown|stopPropagation role="presentation">
+    <div class="header-controls" on:mousedown|stopPropagation on:pointerdown|stopPropagation on:touchstart|stopPropagation role="presentation">
       <label title="Background Color">
         <input
           type="color"

--- a/src/components/TexteClean.svelte
+++ b/src/components/TexteClean.svelte
@@ -313,7 +313,7 @@
     role="presentation"
   >
     <span>Note</span>
-    <div class="header-controls" on:mousedown|stopPropagation role="presentation">
+    <div class="header-controls" on:mousedown|stopPropagation on:pointerdown|stopPropagation on:touchstart|stopPropagation role="presentation">
       <button
         on:click={() => { ensureFocus(); showSettings = !showSettings; }}
         class="gear-btn"


### PR DESCRIPTION
### Motivation
- Header drag handlers were intercepting taps/clicks on header control areas, making buttons and color pickers inside block headers unresponsive.

### Description
- Added `on:pointerdown|stopPropagation` and `on:touchstart|stopPropagation` to `.header-controls` containers to prevent the header drag start from stealing interaction events in `TexteBlock.svelte`, `TexteClean.svelte`, `MusicBlock.svelte`, `EmbedBlock.svelte`, and `TaskBlock.svelte`.

### Testing
- Ran `npm run build` and the build completed successfully with only existing non-blocking warnings reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f663ab8698832eba442b3b6bf9c90d)