### PR TITLE
Add drag-and-drop media import as image blocks

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1091,6 +1091,57 @@
     }
   }
 
+
+
+  function readFileAsDataUrl(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error || new Error('Failed to read file'));
+      reader.readAsDataURL(file);
+    });
+  }
+
+  async function addImageBlockFromFile(file) {
+    if (!file) return;
+    if (!file.type?.startsWith('image/') && !file.type?.startsWith('video/')) return;
+
+    const src = await readFileAsDataUrl(file);
+    if (typeof src !== 'string') return;
+
+    const mediaBlock = applyHistoryTriggers({
+      id: crypto.randomUUID(),
+      type: 'image',
+      content: '',
+      src,
+      position: { x: 100, y: 100 },
+      size: { width: 300, height: 220 },
+      bgColor: '#000000',
+      textColor: '#ffffff',
+      _version: 0
+    });
+
+    blocks = [...blocks, mediaBlock];
+    modeOrders = ensureModeOrders(blocks, modeOrders);
+    await pushHistory(blocks, modeOrders);
+  }
+
+  async function handleModeDrop(event) {
+    event.preventDefault();
+    const files = Array.from(event.dataTransfer?.files || []);
+    const mediaFile = files.find(file => file.type?.startsWith('image/') || file.type?.startsWith('video/'));
+    if (!mediaFile) return;
+
+    try {
+      await addImageBlockFromFile(mediaFile);
+    } catch (error) {
+      console.error('Failed to import dropped media:', error);
+    }
+  }
+
+  function handleModeDragOver(event) {
+    event.preventDefault();
+  }
   async function save() {
     const trimmedName = currentSaveName.trim();
     if (!trimmedName) {
@@ -1783,7 +1834,7 @@
     </div>
   {/if}
 
-  <div class="modes">
+  <div class="modes" role="region" aria-label="Workspace" on:dragover={handleModeDragOver} on:drop={handleModeDrop}>
     <ModeArea
       {mode}
       blocks={modeOrderedBlocks}


### PR DESCRIPTION
### Motivation
- Allow users to drop images or videos onto the workspace and have the app create an `image` block automatically instead of requiring manual file input.

### Description
- Added `readFileAsDataUrl(file)` to read a dropped file as a data URL. 
- Added `addImageBlockFromFile(file)` which creates a new `image` block (default `position` and `size`) with the file data set to `src` and pushes it into history. 
- Added `handleModeDrop(event)` and `handleModeDragOver(event)` to capture drop events and accept only `image/*` or `video/*` files, logging failures and ignoring non-media files. 
- Wired the main workspace container (`<div class="modes">`) to accept `on:dragover`/`on:drop` and added `role="region" aria-label="Workspace"` for accessibility. (Changes in `src/App.svelte`.)

### Testing
- Ran `npm run build` and the build completed successfully; Svelte accessibility/style warnings unrelated to the new handlers remain but did not block the build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6647b2474832ea3949d7cc5d58862)