### PR TITLE
Enable drag-and-drop import of image/video files into workspace

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1091,6 +1091,57 @@
     }
   }
 
+
+
+  function readFileAsDataUrl(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(reader.error || new Error('Failed to read file'));
+      reader.readAsDataURL(file);
+    });
+  }
+
+  async function addImageBlockFromFile(file) {
+    if (!file) return;
+    if (!file.type?.startsWith('image/') && !file.type?.startsWith('video/')) return;
+
+    const src = await readFileAsDataUrl(file);
+    if (typeof src !== 'string') return;
+
+    const mediaBlock = applyHistoryTriggers({
+      id: crypto.randomUUID(),
+      type: 'image',
+      content: '',
+      src,
+      position: { x: 100, y: 100 },
+      size: { width: 300, height: 200 },
+      bgColor: '#000000',
+      textColor: '#ffffff',
+      _version: 0
+    });
+
+    blocks = [...blocks, mediaBlock];
+    modeOrders = ensureModeOrders(blocks, modeOrders);
+    await pushHistory(blocks, modeOrders);
+  }
+
+  async function handleModeDrop(event) {
+    event.preventDefault();
+    const files = Array.from(event.dataTransfer?.files || []);
+    const mediaFile = files.find(file => file.type?.startsWith('image/') || file.type?.startsWith('video/'));
+    if (!mediaFile) return;
+
+    try {
+      await addImageBlockFromFile(mediaFile);
+    } catch (error) {
+      console.error('Failed to import dropped media:', error);
+    }
+  }
+
+  function handleModeDragOver(event) {
+    event.preventDefault();
+  }
   async function save() {
     const trimmedName = currentSaveName.trim();
     if (!trimmedName) {
@@ -1783,7 +1834,7 @@
     </div>
   {/if}
 
-  <div class="modes">
+  <div class="modes" role="region" aria-label="Workspace" on:dragover={handleModeDragOver} on:drop={handleModeDrop}>
     <ModeArea
       {mode}
       blocks={modeOrderedBlocks}


### PR DESCRIPTION
### Motivation
- Allow users to drop image or video files directly into the workspace to create media blocks without using external uploads.
- Provide a simple file-to-dataURL flow that integrates with the app's history and autosave mechanisms.
- Improve accessibility and semantics for the workspace container via ARIA attributes.

### Description
- Added `readFileAsDataUrl` utility to convert dropped `File` objects into data URLs using `FileReader` and promises.
- Implemented `addImageBlockFromFile` which validates image/video MIME types, creates a new media block (with `crypto.randomUUID()` id), and pushes it into `blocks` with history via `pushHistory` and `ensureModeOrders`.
- Added drag-and-drop handlers `handleModeDrop` and `handleModeDragOver` on the workspace container and wired them into the `.modes` element with `on:dragover` and `on:drop` attributes, and added `role="region"` and `aria-label="Workspace"` to the container.

### Testing
- Ran the automated test suite with `npm test`, and the tests completed successfully.
- Performed a build with `npm run build`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6647b2474832ea3949d7cc5d58862)