### PR TITLE
Add Shift+mousewheel zoom support to canvas

### DIFF
--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -25,6 +25,7 @@
   const BLOCK_MARGIN_BOTTOM = 20;
   const MIN_ZOOM = 0.2;
   const MAX_ZOOM = 4;
+  const WHEEL_ZOOM_SENSITIVITY = 0.0015;
 
   let scale = 1;
   let lastDistance = null;
@@ -116,13 +117,21 @@
     };
   }
 
-  function fitToViewport() {
-    if (!canvasRef) return;
+  function getViewportScaleFloor() {
     const controlsHeight = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--controls-height')) || 56;
     const availableWidth = Math.max(window.innerWidth, 1);
     const availableHeight = Math.max(window.innerHeight - controlsHeight, 1);
     const fittedScale = Math.min(availableWidth / canvasWidth, availableHeight / canvasHeight);
-    scale = Math.min(1, fittedScale);
+    return Math.min(1, fittedScale);
+  }
+
+  function getMinAllowedScale() {
+    return Math.min(MIN_ZOOM, getViewportScaleFloor());
+  }
+
+  function fitToViewport() {
+    if (!canvasRef) return;
+    scale = getViewportScaleFloor();
     canvasRef.scrollLeft = 0;
     canvasRef.scrollTop = 0;
   }
@@ -140,7 +149,7 @@
     const newDistance = getDistance(event.touches);
     const newMidpoint = getMidpoint(event.touches);
     const oldScale = scale;
-    const nextScale = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, oldScale * (newDistance / lastDistance)));
+    const nextScale = Math.max(getMinAllowedScale(), Math.min(MAX_ZOOM, oldScale * (newDistance / lastDistance)));
     if (nextScale === oldScale) return;
 
     const rect = canvasRef.getBoundingClientRect();
@@ -155,6 +164,28 @@
 
     lastDistance = newDistance;
     lastMidpoint = newMidpoint;
+  }
+
+
+  function onWheel(event) {
+    if (!event.shiftKey || !canvasRef) return;
+    if (event.cancelable) event.preventDefault();
+
+    const oldScale = scale;
+    const zoomFactor = Math.exp(-event.deltaY * WHEEL_ZOOM_SENSITIVITY);
+    const nextScale = Math.max(getMinAllowedScale(), Math.min(MAX_ZOOM, oldScale * zoomFactor));
+
+    if (nextScale === oldScale) return;
+
+    const rect = canvasRef.getBoundingClientRect();
+    const anchorX = event.clientX - rect.left;
+    const anchorY = event.clientY - rect.top;
+    const contentX = (canvasRef.scrollLeft + anchorX) / oldScale;
+    const contentY = (canvasRef.scrollTop + anchorY) / oldScale;
+
+    scale = nextScale;
+    canvasRef.scrollLeft = Math.max(0, contentX * scale - anchorX);
+    canvasRef.scrollTop = Math.max(0, contentY * scale - anchorY);
   }
 
   function onTouchEnd(event) {
@@ -248,6 +279,7 @@
   on:touchstart={onTouchStart}
   on:touchmove={onTouchMove}
   on:touchend={onTouchEnd}
+  on:wheel={onWheel}
 >
     <div
       class="canvas-zoom-shell"


### PR DESCRIPTION
### Motivation
- Enable desktop users to zoom the canvas quickly using the `Shift + mousewheel` shortcut. 
- Keep zooming centered on the cursor so the visual focus stays stable during scale changes. 
- Ensure users can always zoom out far enough to view the full canvas bounds (blocks + margins) by applying a viewport-fit floor to the minimum allowed scale.

### Description
- Added `WHEEL_ZOOM_SENSITIVITY` and an `onWheel` handler that performs cursor-anchored exponential zoom when `Shift` is held and binds it to the canvas element in `src/Modes/CanvasMode.svelte`.
- Introduced `getViewportScaleFloor` and `getMinAllowedScale` helpers and updated `fitToViewport` to use the viewport-fit floor so the canvas can be fit to the full content extents.
- Reused the same `getMinAllowedScale` logic to clamp pinch-to-zoom (`onTouchMove`) so touch and mousewheel zoom behaviors remain consistent.

### Testing
- Ran `npm run build` which completed successfully (build succeeded; Svelte/Vite warnings are pre-existing and non-blocking).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66982d6b8832e8a04707e2162a947)