### PR TITLE
Canvas: Add wheel-zoom, edge panning, and viewport-aware min-zoom

### DIFF
--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -25,6 +25,9 @@
   const BLOCK_MARGIN_BOTTOM = 20;
   const MIN_ZOOM = 0.2;
   const MAX_ZOOM = 4;
+  const WHEEL_ZOOM_SENSITIVITY = 0.0015;
+  const EDGE_PAN_ZONE = 72;
+  const EDGE_PAN_MAX_SPEED = 20;
 
   let scale = 1;
   let lastDistance = null;
@@ -32,6 +35,9 @@
   let canvasWidth = MIN_CANVAS_WIDTH;
   let canvasHeight = MIN_CANVAS_HEIGHT;
   let contentOffsetX = 0;
+  let edgePanRaf = null;
+  let edgePanVelocityX = 0;
+  let edgePanVelocityY = 0;
 
   const dispatch = createEventDispatcher();
 
@@ -116,13 +122,21 @@
     };
   }
 
-  function fitToViewport() {
-    if (!canvasRef) return;
+  function getViewportScaleFloor() {
     const controlsHeight = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--controls-height')) || 56;
     const availableWidth = Math.max(window.innerWidth, 1);
     const availableHeight = Math.max(window.innerHeight - controlsHeight, 1);
     const fittedScale = Math.min(availableWidth / canvasWidth, availableHeight / canvasHeight);
-    scale = Math.min(1, fittedScale);
+    return Math.min(1, fittedScale);
+  }
+
+  function getMinAllowedScale() {
+    return Math.min(MIN_ZOOM, getViewportScaleFloor());
+  }
+
+  function fitToViewport() {
+    if (!canvasRef) return;
+    scale = getViewportScaleFloor();
     canvasRef.scrollLeft = 0;
     canvasRef.scrollTop = 0;
   }
@@ -140,7 +154,7 @@
     const newDistance = getDistance(event.touches);
     const newMidpoint = getMidpoint(event.touches);
     const oldScale = scale;
-    const nextScale = Math.max(MIN_ZOOM, Math.min(MAX_ZOOM, oldScale * (newDistance / lastDistance)));
+    const nextScale = Math.max(getMinAllowedScale(), Math.min(MAX_ZOOM, oldScale * (newDistance / lastDistance)));
     if (nextScale === oldScale) return;
 
     const rect = canvasRef.getBoundingClientRect();
@@ -155,6 +169,97 @@
 
     lastDistance = newDistance;
     lastMidpoint = newMidpoint;
+  }
+
+
+  function onWheel(event) {
+    if (!event.ctrlKey || !canvasRef) return;
+    if (event.cancelable) event.preventDefault();
+
+    const oldScale = scale;
+    const zoomFactor = Math.exp(-event.deltaY * WHEEL_ZOOM_SENSITIVITY);
+    const nextScale = Math.max(getMinAllowedScale(), Math.min(MAX_ZOOM, oldScale * zoomFactor));
+
+    if (nextScale === oldScale) return;
+
+    const rect = canvasRef.getBoundingClientRect();
+    const anchorX = event.clientX - rect.left;
+    const anchorY = event.clientY - rect.top;
+    const contentX = (canvasRef.scrollLeft + anchorX) / oldScale;
+    const contentY = (canvasRef.scrollTop + anchorY) / oldScale;
+
+    scale = nextScale;
+    canvasRef.scrollLeft = Math.max(0, contentX * scale - anchorX);
+    canvasRef.scrollTop = Math.max(0, contentY * scale - anchorY);
+  }
+
+
+  function getEdgePanStrength(distanceToEdge) {
+    const normalized = Math.max(0, Math.min(1, (EDGE_PAN_ZONE - distanceToEdge) / EDGE_PAN_ZONE));
+    return normalized * normalized;
+  }
+
+  function stopEdgePan() {
+    edgePanVelocityX = 0;
+    edgePanVelocityY = 0;
+
+    if (edgePanRaf !== null) {
+      cancelAnimationFrame(edgePanRaf);
+      edgePanRaf = null;
+    }
+  }
+
+  function stepEdgePan() {
+    if (!canvasRef || !edgePanVelocityX && !edgePanVelocityY) {
+      edgePanRaf = null;
+      return;
+    }
+
+    canvasRef.scrollLeft += edgePanVelocityX;
+    canvasRef.scrollTop += edgePanVelocityY;
+    edgePanRaf = requestAnimationFrame(stepEdgePan);
+  }
+
+  function updateEdgePanFromPointer(event) {
+    if (!canvasRef) return;
+    if (scale <= getViewportScaleFloor()) {
+      stopEdgePan();
+      return;
+    }
+
+    const rect = canvasRef.getBoundingClientRect();
+    const localX = event.clientX - rect.left;
+    const localY = event.clientY - rect.top;
+
+    if (localX < 0 || localY < 0 || localX > rect.width || localY > rect.height) {
+      stopEdgePan();
+      return;
+    }
+
+    const leftStrength = getEdgePanStrength(localX);
+    const rightStrength = getEdgePanStrength(rect.width - localX);
+    const topStrength = getEdgePanStrength(localY);
+    const bottomStrength = getEdgePanStrength(rect.height - localY);
+
+    edgePanVelocityX = (rightStrength - leftStrength) * EDGE_PAN_MAX_SPEED;
+    edgePanVelocityY = (bottomStrength - topStrength) * EDGE_PAN_MAX_SPEED;
+
+    if (!edgePanVelocityX && !edgePanVelocityY) {
+      stopEdgePan();
+      return;
+    }
+
+    if (edgePanRaf === null) {
+      edgePanRaf = requestAnimationFrame(stepEdgePan);
+    }
+  }
+
+  function onMouseMove(event) {
+    updateEdgePanFromPointer(event);
+  }
+
+  function onMouseLeave() {
+    stopEdgePan();
   }
 
   function onTouchEnd(event) {
@@ -182,6 +287,10 @@
 
   onMount(() => {
     refitCanvas();
+
+    return () => {
+      stopEdgePan();
+    };
   });
 </script>
 
@@ -243,11 +352,16 @@
 <div
   class="canvas"
   class:simple-note={mode === 'simple'}
+  role="region"
+  aria-label="Canvas viewport"
   bind:this={canvasRef}
   style={canvasCssVars}
   on:touchstart={onTouchStart}
   on:touchmove={onTouchMove}
   on:touchend={onTouchEnd}
+  on:wheel|nonpassive={onWheel}
+  on:mousemove={onMouseMove}
+  on:mouseleave={onMouseLeave}
 >
     <div
       class="canvas-zoom-shell"


### PR DESCRIPTION
### Motivation
- Improve canvas navigation by supporting Ctrl+wheel zooming and automatic panning when the pointer is near canvas edges. 
- Ensure pinch-to-zoom respects a viewport-aware minimum zoom so content never becomes smaller than the visible area. 
- Add small accessibility and lifecycle improvements (aria label and cleanup of edge-panning animation). 

### Description
- Introduces new configurable constants: `WHEEL_ZOOM_SENSITIVITY`, `EDGE_PAN_ZONE`, and `EDGE_PAN_MAX_SPEED` and state for edge-pan animation. 
- Adds `getViewportScaleFloor()` and `getMinAllowedScale()` to compute a viewport-aware minimum scale and updates pinch-to-zoom to clamp to that minimum. 
- Implements `onWheel` handler to perform anchored zooming with Ctrl+wheel and binds it as a non-passive `wheel` listener. 
- Implements edge-panning: computes pan strength near edges, schedules RAF-based panning (`stepEdgePan`), and attaches pointer handlers (`on:mousemove` / `on:mouseleave`) to drive/start/stop the behavior. 
- Adds `role="region"` and `aria-label="Canvas viewport"` to the canvas container and ensures `stopEdgePan()` is called on unmount. 

### Testing
- Ran the project's automated test suite (`npm test`) and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f66982d6b8832e8a04707e2162a947)