### PR TITLE
Persist SimpleNote column count and add drag-and-drop block reordering

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -148,6 +148,7 @@
 
   const CONTROL_COLOR_STORAGE_KEY = 'controlColors';
   const LAST_SAVE_STORAGE_KEY = 'lastLoadedSave';
+  const MODE_SETTINGS_STORAGE_KEY = 'modeSettings';
   const BOOT_LOAD_GUARD_STORAGE_KEY = 'bootLoadGuard';
   const FALLBACK_SAVE_NAME = 'Fallback';
   const DEFAULT_MODE_SETTINGS = {
@@ -222,6 +223,29 @@
       return localStorage.getItem(LAST_SAVE_STORAGE_KEY);
     } catch (error) {
       return null;
+    }
+  }
+
+  function loadStoredModeSettings() {
+    if (typeof localStorage === 'undefined') return null;
+    try {
+      const serialized = localStorage.getItem(MODE_SETTINGS_STORAGE_KEY);
+      if (!serialized) return null;
+      return normalizeModeSettings(JSON.parse(serialized));
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function persistModeSettings(settings) {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem(
+        MODE_SETTINGS_STORAGE_KEY,
+        JSON.stringify(normalizeModeSettings(settings))
+      );
+    } catch (error) {
+      // no-op
     }
   }
 
@@ -780,7 +804,7 @@
   let observedControlsEl;
 
   let mode = getDefaultModeForViewport();
-  let modeSettings = normalizeModeSettings();
+  let modeSettings = normalizeModeSettings(loadStoredModeSettings());
   $: simpleNoteColumnCount = modeSettings.simple.columnCount;
   $: activeModeDefinition = getModeDefinition(mode);
   $: showRightControls = activeModeDefinition?.showRightControls !== false;
@@ -1455,7 +1479,27 @@
       }
     });
     modeSettings = nextModeSettings;
+    persistModeSettings(nextModeSettings);
     await persistAutosave(blocks, modeOrders, nextModeSettings);
+  }
+
+  async function handleSimpleModeReorder(event) {
+    const sourceBlockId = event.detail?.sourceBlockId;
+    const targetBlockId = event.detail?.targetBlockId;
+    const ordersForMode = normalizedModeOrders[mode] || [];
+    const sourceIndex = ordersForMode.indexOf(sourceBlockId);
+    const targetIndex = ordersForMode.indexOf(targetBlockId);
+
+    if (sourceIndex === -1 || targetIndex === -1 || sourceIndex === targetIndex) return;
+
+    const updatedOrder = [...ordersForMode];
+    updatedOrder.splice(sourceIndex, 1);
+    updatedOrder.splice(targetIndex, 0, sourceBlockId);
+    modeOrders = {
+      ...modeOrders,
+      [mode]: updatedOrder
+    };
+    await pushHistory(blocks, modeOrders);
   }
 
   function setupControlsObserver() {
@@ -1849,6 +1893,7 @@
       on:delete={deleteBlockHandler}
       on:focusToggle={handleFocusToggle}
       on:modeSettingChange={handleModeSettingChange}
+      on:reorderBlocks={handleSimpleModeReorder}
     />
   </div>
 </div>

--- a/src/Modes/ModeSwitcher.svelte
+++ b/src/Modes/ModeSwitcher.svelte
@@ -35,6 +35,10 @@
     dispatch('focusToggle', event.detail);
   }
 
+  function reorderBlocksHandler(event) {
+    dispatch('reorderBlocks', event.detail);
+  }
+
   function updateWidth() {
     width = window.innerWidth;
   }
@@ -76,6 +80,7 @@
       on:update={updateBlockHandler}
       on:delete={deleteBlockHandler}
       on:focusToggle={focusToggleHandler}
+      on:reorderBlocks={reorderBlocksHandler}
     />
 
   {:else if mode === 'habit'}

--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -185,6 +185,7 @@
 
   let imageInputRefs = {};
   let imageTapTracker = {};
+  let draggedBlockId = null;
 
   function setImageInputRef(blockId, node) {
     if (node) {
@@ -261,6 +262,29 @@
       event.preventDefault();
       openImagePicker(block.id);
     }
+  }
+
+  function handleDragStart(event, blockId) {
+    draggedBlockId = blockId;
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('text/plain', blockId);
+  }
+
+  function handleDragOver(event) {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  }
+
+  function handleDrop(event, targetBlockId) {
+    event.preventDefault();
+    const sourceBlockId = event.dataTransfer.getData('text/plain') || draggedBlockId;
+    draggedBlockId = null;
+    if (!sourceBlockId || !targetBlockId || sourceBlockId === targetBlockId) return;
+    dispatch('reorderBlocks', { sourceBlockId, targetBlockId });
+  }
+
+  function handleDragEnd() {
+    draggedBlockId = null;
   }
 
   $: normalizedColumnCount = Math.max(1, Number.parseInt(columnCount, 10) || 2);
@@ -551,6 +575,11 @@ li {
           tabindex="0"
           aria-pressed={block.id === focusedBlockId}
           on:keydown={(event) => handleBlockKeydown(event, block.id)}
+          draggable="true"
+          on:dragstart={(event) => handleDragStart(event, block.id)}
+          on:dragover={handleDragOver}
+          on:drop={(event) => handleDrop(event, block.id)}
+          on:dragend={handleDragEnd}
         >
           {#if block.type === 'text' || block.type === 'cleantext'}
             <textarea


### PR DESCRIPTION
### Motivation
- Remember the Simple Note column layout across refreshes so users don't have to re-select the number of columns each time.
- Allow users to reorder blocks in Simple Note mode by dragging them to the desired position.

### Description
- Persisted Simple Note settings using a new `MODE_SETTINGS_STORAGE_KEY` and added `loadStoredModeSettings` / `persistModeSettings` helpers in `src/App.svelte`, and initialize `modeSettings` from stored values (`modeSettings = normalizeModeSettings(loadStoredModeSettings())`).
- Updated the mode setting change flow so `handleModeSettingChange` now calls `persistModeSettings(nextModeSettings)` before autosave to local storage (column count is now saved immediately).
- Implemented drag-and-drop in `src/Modes/SimpleNoteMode.svelte` by adding `draggable` attributes and handlers `handleDragStart`, `handleDragOver`, `handleDrop`, and `handleDragEnd`, and dispatching a `reorderBlocks` event with `sourceBlockId` and `targetBlockId`.
- Wired the `reorderBlocks` event through `src/Modes/ModeSwitcher.svelte` (added `reorderBlocksHandler`) into `src/App.svelte` and implemented `handleSimpleModeReorder` to update `modeOrders` and push the change into the undo/redo history.

### Testing
- Ran `npm run build` and the production build completed successfully (the build output included unrelated Svelte warnings but no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f680c087e8832e935645c5500a3ee4)