### PR TITLE
Persist simple mode settings and add drag-and-drop reordering for Simple mode

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -148,6 +148,7 @@
 
   const CONTROL_COLOR_STORAGE_KEY = 'controlColors';
   const LAST_SAVE_STORAGE_KEY = 'lastLoadedSave';
+  const MODE_SETTINGS_STORAGE_KEY = 'modeSettings';
   const BOOT_LOAD_GUARD_STORAGE_KEY = 'bootLoadGuard';
   const FALLBACK_SAVE_NAME = 'Fallback';
   const DEFAULT_MODE_SETTINGS = {
@@ -222,6 +223,29 @@
       return localStorage.getItem(LAST_SAVE_STORAGE_KEY);
     } catch (error) {
       return null;
+    }
+  }
+
+  function loadStoredModeSettings() {
+    if (typeof localStorage === 'undefined') return null;
+    try {
+      const serialized = localStorage.getItem(MODE_SETTINGS_STORAGE_KEY);
+      if (!serialized) return null;
+      return normalizeModeSettings(JSON.parse(serialized));
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function persistModeSettings(settings) {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem(
+        MODE_SETTINGS_STORAGE_KEY,
+        JSON.stringify(normalizeModeSettings(settings))
+      );
+    } catch (error) {
+      // no-op
     }
   }
 
@@ -780,7 +804,7 @@
   let observedControlsEl;
 
   let mode = getDefaultModeForViewport();
-  let modeSettings = normalizeModeSettings();
+  let modeSettings = normalizeModeSettings(loadStoredModeSettings());
   $: simpleNoteColumnCount = modeSettings.simple.columnCount;
   $: activeModeDefinition = getModeDefinition(mode);
   $: showRightControls = activeModeDefinition?.showRightControls !== false;
@@ -1443,6 +1467,7 @@
   }
 
   async function handleModeSettingChange(event) {
+    const previousColumnCount = modeSettings.simple.columnCount;
     const nextColumnCount = Math.max(
       1,
       Number.parseInt(event.detail?.columnCount, 10) || DEFAULT_MODE_SETTINGS.simple.columnCount
@@ -1455,7 +1480,50 @@
       }
     });
     modeSettings = nextModeSettings;
+    persistModeSettings(nextModeSettings);
+    if (previousColumnCount !== nextColumnCount) {
+      const redistributedBlocks = blocks.map((block, index) => ({
+        ...block,
+        simpleColumn: index % nextColumnCount
+      }));
+      await pushHistory(redistributedBlocks, modeOrders);
+      await persistAutosave(redistributedBlocks, modeOrders, nextModeSettings);
+      return;
+    }
     await persistAutosave(blocks, modeOrders, nextModeSettings);
+  }
+
+  async function handleSimpleModeReorder(event) {
+    const sourceBlockId = event.detail?.sourceBlockId;
+    const targetBlockId = event.detail?.targetBlockId;
+    const sourceBlockIdKey = String(sourceBlockId);
+    const targetBlockIdKey = targetBlockId == null ? null : String(targetBlockId);
+    const targetColumn = Math.max(0, Number.parseInt(event.detail?.targetColumn, 10) || 0);
+    const placement = event.detail?.placement === 'end' ? 'end' : 'before';
+    const ordersForMode = normalizedModeOrders[mode] || [];
+    const sourceIndex = ordersForMode.findIndex((id) => String(id) === sourceBlockIdKey);
+    const targetIndex = targetBlockIdKey ? ordersForMode.findIndex((id) => String(id) === targetBlockIdKey) : -1;
+
+    if (sourceIndex === -1) return;
+    if (targetBlockId && (targetIndex === -1 || sourceIndex === targetIndex)) return;
+
+    const updatedOrder = [...ordersForMode];
+    updatedOrder.splice(sourceIndex, 1);
+    if (placement === 'end' || targetIndex === -1) {
+      updatedOrder.push(sourceBlockId);
+    } else {
+      const insertionIndex = sourceIndex < targetIndex ? targetIndex - 1 : targetIndex;
+      updatedOrder.splice(insertionIndex, 0, sourceBlockId);
+    }
+
+    const updatedBlocks = blocks.map((block) =>
+      block.id === sourceBlockId ? { ...block, simpleColumn: targetColumn } : block
+    );
+    modeOrders = {
+      ...modeOrders,
+      [mode]: updatedOrder
+    };
+    await pushHistory(updatedBlocks, modeOrders);
   }
 
   function setupControlsObserver() {
@@ -1849,6 +1917,7 @@
       on:delete={deleteBlockHandler}
       on:focusToggle={handleFocusToggle}
       on:modeSettingChange={handleModeSettingChange}
+      on:reorderBlocks={handleSimpleModeReorder}
     />
   </div>
 </div>

--- a/src/Modes/ModeSwitcher.svelte
+++ b/src/Modes/ModeSwitcher.svelte
@@ -35,6 +35,10 @@
     dispatch('focusToggle', event.detail);
   }
 
+  function reorderBlocksHandler(event) {
+    dispatch('reorderBlocks', event.detail);
+  }
+
   function updateWidth() {
     width = window.innerWidth;
   }
@@ -76,6 +80,7 @@
       on:update={updateBlockHandler}
       on:delete={deleteBlockHandler}
       on:focusToggle={focusToggleHandler}
+      on:reorderBlocks={reorderBlocksHandler}
     />
 
   {:else if mode === 'habit'}

--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -185,6 +185,7 @@
 
   let imageInputRefs = {};
   let imageTapTracker = {};
+  let draggedBlockId = null;
 
   function setImageInputRef(blockId, node) {
     if (node) {
@@ -263,10 +264,45 @@
     }
   }
 
+  function handleDragStart(event, blockId) {
+    draggedBlockId = blockId;
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('text/plain', blockId);
+  }
+
+  function handleDragOver(event) {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  }
+
+  function handleDrop(event, targetBlockId, targetColumn, placement = 'before') {
+    event.preventDefault();
+    event.stopPropagation();
+    const sourceBlockId = event.dataTransfer.getData('text/plain') || draggedBlockId;
+    draggedBlockId = null;
+    if (!sourceBlockId) return;
+    if (targetBlockId && sourceBlockId === targetBlockId) return;
+    dispatch('reorderBlocks', { sourceBlockId, targetBlockId, targetColumn, placement });
+  }
+
+  function handleDragEnd() {
+    draggedBlockId = null;
+  }
+
   $: normalizedColumnCount = Math.max(1, Number.parseInt(columnCount, 10) || 2);
-  $: renderColumns = Array.from({ length: normalizedColumnCount }, (_, columnIndex) =>
-    blocks.filter((_, blockIndex) => blockIndex % normalizedColumnCount === columnIndex)
-  );
+  $: renderColumns = Array.from({ length: normalizedColumnCount }, (_, columnIndex) => ({ columnIndex, blocks: [] }));
+  $: {
+    renderColumns.forEach((column) => {
+      column.blocks = [];
+    });
+    blocks.forEach((block, blockIndex) => {
+      const savedColumn = Number.parseInt(block.simpleColumn, 10);
+      const normalizedColumn = Number.isInteger(savedColumn) && savedColumn >= 0
+        ? Math.min(savedColumn, normalizedColumnCount - 1)
+        : blockIndex % normalizedColumnCount;
+      renderColumns[normalizedColumn].blocks.push(block);
+    });
+  }
 
   // Resize all textareas when component mounts
   onMount(() => {
@@ -534,8 +570,12 @@ li {
 
 <div class="simple-wrapper" bind:this={canvasRef} style={`${canvasCssVars} --simple-note-columns: ${normalizedColumnCount};`}>
   {#each renderColumns as column}
-    <div class="simple-column">
-      {#each column as block (blockKey(block))}
+    <div
+      class="simple-column"
+      on:dragover={handleDragOver}
+      on:drop={(event) => handleDrop(event, null, column.columnIndex, 'end')}
+    >
+      {#each column.blocks as block (blockKey(block))}
       <div class="canvas">
         <div
           class="container"
@@ -551,6 +591,11 @@ li {
           tabindex="0"
           aria-pressed={block.id === focusedBlockId}
           on:keydown={(event) => handleBlockKeydown(event, block.id)}
+          draggable="true"
+          on:dragstart={(event) => handleDragStart(event, block.id)}
+          on:dragover={handleDragOver}
+          on:drop={(event) => handleDrop(event, block.id, column.columnIndex, 'before')}
+          on:dragend={handleDragEnd}
         >
           {#if block.type === 'text' || block.type === 'cleantext'}
             <textarea


### PR DESCRIPTION
### Motivation

- Persist user layout choices for the Simple mode (column counts and per-block column assignment) so the layout is stable across sessions.
- Allow intuitive drag-and-drop reordering and column moves of blocks in Simple mode to improve UX for arranging notes.

### Description

- Add `MODE_SETTINGS_STORAGE_KEY`, `loadStoredModeSettings`, and `persistModeSettings` to persist and normalize `modeSettings` to `localStorage` and initialize `modeSettings` from stored data. 
- Update `modeSettings` initialization to call `normalizeModeSettings(loadStoredModeSettings())` and update `handleModeSettingChange` to persist changes and redistribute blocks (updating each block's `simpleColumn`) when `columnCount` changes, pushing history and persisting autosave. 
- Implement `handleSimpleModeReorder` to accept reorder events, update `modeOrders` and per-block `simpleColumn` values, and push history. 
- Wire events through the UI stack by dispatching and listening for `reorderBlocks` from `ModeSwitcher` to `ModeArea`/`App`, and add drag-and-drop handlers to `SimpleNoteMode` including `handleDragStart`, `handleDragOver`, `handleDrop`, and `handleDragEnd`. 
- Change `SimpleNoteMode` column rendering to honor `block.simpleColumn` when building `renderColumns`, and make columns and block containers accept drops and be draggable so blocks can be moved between columns or reordered within a column.

### Testing

- Ran the existing automated test suite using `npm test`, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f680c087e8832e935645c5500a3ee4)