### PR TITLE
Persist simple-mode column settings and add drag-and-drop reordering

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -148,6 +148,7 @@
 
   const CONTROL_COLOR_STORAGE_KEY = 'controlColors';
   const LAST_SAVE_STORAGE_KEY = 'lastLoadedSave';
+  const MODE_SETTINGS_STORAGE_KEY = 'modeSettings';
   const BOOT_LOAD_GUARD_STORAGE_KEY = 'bootLoadGuard';
   const FALLBACK_SAVE_NAME = 'Fallback';
   const DEFAULT_MODE_SETTINGS = {
@@ -222,6 +223,29 @@
       return localStorage.getItem(LAST_SAVE_STORAGE_KEY);
     } catch (error) {
       return null;
+    }
+  }
+
+  function loadStoredModeSettings() {
+    if (typeof localStorage === 'undefined') return null;
+    try {
+      const serialized = localStorage.getItem(MODE_SETTINGS_STORAGE_KEY);
+      if (!serialized) return null;
+      return normalizeModeSettings(JSON.parse(serialized));
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function persistModeSettings(settings) {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem(
+        MODE_SETTINGS_STORAGE_KEY,
+        JSON.stringify(normalizeModeSettings(settings))
+      );
+    } catch (error) {
+      // no-op
     }
   }
 
@@ -780,7 +804,7 @@
   let observedControlsEl;
 
   let mode = getDefaultModeForViewport();
-  let modeSettings = normalizeModeSettings();
+  let modeSettings = normalizeModeSettings(loadStoredModeSettings());
   $: simpleNoteColumnCount = modeSettings.simple.columnCount;
   $: activeModeDefinition = getModeDefinition(mode);
   $: showRightControls = activeModeDefinition?.showRightControls !== false;
@@ -1443,6 +1467,7 @@
   }
 
   async function handleModeSettingChange(event) {
+    const previousColumnCount = modeSettings.simple.columnCount;
     const nextColumnCount = Math.max(
       1,
       Number.parseInt(event.detail?.columnCount, 10) || DEFAULT_MODE_SETTINGS.simple.columnCount
@@ -1455,7 +1480,63 @@
       }
     });
     modeSettings = nextModeSettings;
+    persistModeSettings(nextModeSettings);
+    if (previousColumnCount !== nextColumnCount) {
+      const redistributedBlocks = blocks.map((block, index) => ({
+        ...block,
+        simpleColumn: index % nextColumnCount
+      }));
+      await pushHistory(redistributedBlocks, modeOrders);
+      await persistAutosave(redistributedBlocks, modeOrders, nextModeSettings);
+      return;
+    }
     await persistAutosave(blocks, modeOrders, nextModeSettings);
+  }
+
+  async function handleSimpleModeReorder(event) {
+    const sourceBlockId = event.detail?.sourceBlockId;
+    const targetBlockId = event.detail?.targetBlockId;
+    const sourceBlockIdKey = String(sourceBlockId);
+    const targetBlockIdKey = targetBlockId == null ? null : String(targetBlockId);
+    const targetColumn = Math.max(0, Number.parseInt(event.detail?.targetColumn, 10) || 0);
+    const placement = event.detail?.placement || 'before';
+    const ordersForMode = normalizedModeOrders[mode] || [];
+    const sourceIndex = ordersForMode.findIndex((id) => String(id) === sourceBlockIdKey);
+    const targetIndex = targetBlockIdKey ? ordersForMode.findIndex((id) => String(id) === targetBlockIdKey) : -1;
+
+    if (sourceIndex === -1) return;
+    if (targetBlockId && (targetIndex === -1 || sourceIndex === targetIndex)) return;
+
+    const updatedOrder = [...ordersForMode];
+    updatedOrder.splice(sourceIndex, 1);
+    if (placement === 'endInColumn') {
+      const lastInTargetColumnId = [...updatedOrder]
+        .reverse()
+        .find((id) => {
+          const block = blocks.find((entry) => String(entry.id) === String(id));
+          return (block?.simpleColumn ?? 0) === targetColumn || (String(id) === sourceBlockIdKey);
+        });
+      if (!lastInTargetColumnId) {
+        updatedOrder.push(sourceBlockId);
+      } else {
+        const lastIndex = updatedOrder.findIndex((id) => String(id) === String(lastInTargetColumnId));
+        updatedOrder.splice(lastIndex + 1, 0, sourceBlockId);
+      }
+    } else if (placement === 'end' || targetIndex === -1) {
+      updatedOrder.push(sourceBlockId);
+    } else {
+      const insertionIndex = sourceIndex < targetIndex ? targetIndex - 1 : targetIndex;
+      updatedOrder.splice(insertionIndex, 0, sourceBlockId);
+    }
+
+    const updatedBlocks = blocks.map((block) =>
+      block.id === sourceBlockId ? { ...block, simpleColumn: targetColumn } : block
+    );
+    modeOrders = {
+      ...modeOrders,
+      [mode]: updatedOrder
+    };
+    await pushHistory(updatedBlocks, modeOrders);
   }
 
   function setupControlsObserver() {
@@ -1849,6 +1930,7 @@
       on:delete={deleteBlockHandler}
       on:focusToggle={handleFocusToggle}
       on:modeSettingChange={handleModeSettingChange}
+      on:reorderBlocks={handleSimpleModeReorder}
     />
   </div>
 </div>

--- a/src/Modes/ModeSwitcher.svelte
+++ b/src/Modes/ModeSwitcher.svelte
@@ -35,6 +35,10 @@
     dispatch('focusToggle', event.detail);
   }
 
+  function reorderBlocksHandler(event) {
+    dispatch('reorderBlocks', event.detail);
+  }
+
   function updateWidth() {
     width = window.innerWidth;
   }
@@ -76,6 +80,7 @@
       on:update={updateBlockHandler}
       on:delete={deleteBlockHandler}
       on:focusToggle={focusToggleHandler}
+      on:reorderBlocks={reorderBlocksHandler}
     />
 
   {:else if mode === 'habit'}

--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -185,6 +185,7 @@
 
   let imageInputRefs = {};
   let imageTapTracker = {};
+  let draggedBlockId = null;
 
   function setImageInputRef(blockId, node) {
     if (node) {
@@ -263,10 +264,45 @@
     }
   }
 
+  function handleDragStart(event, blockId) {
+    draggedBlockId = blockId;
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('text/plain', blockId);
+  }
+
+  function handleDragOver(event) {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  }
+
+  function handleDrop(event, targetBlockId, targetColumn, placement = 'before') {
+    event.preventDefault();
+    event.stopPropagation();
+    const sourceBlockId = event.dataTransfer.getData('text/plain') || draggedBlockId;
+    draggedBlockId = null;
+    if (!sourceBlockId) return;
+    if (targetBlockId && sourceBlockId === targetBlockId) return;
+    dispatch('reorderBlocks', { sourceBlockId, targetBlockId, targetColumn, placement });
+  }
+
+  function handleDragEnd() {
+    draggedBlockId = null;
+  }
+
   $: normalizedColumnCount = Math.max(1, Number.parseInt(columnCount, 10) || 2);
-  $: renderColumns = Array.from({ length: normalizedColumnCount }, (_, columnIndex) =>
-    blocks.filter((_, blockIndex) => blockIndex % normalizedColumnCount === columnIndex)
-  );
+  $: renderColumns = Array.from({ length: normalizedColumnCount }, (_, columnIndex) => ({ columnIndex, blocks: [] }));
+  $: {
+    renderColumns.forEach((column) => {
+      column.blocks = [];
+    });
+    blocks.forEach((block, blockIndex) => {
+      const savedColumn = Number.parseInt(block.simpleColumn, 10);
+      const normalizedColumn = Number.isInteger(savedColumn) && savedColumn >= 0
+        ? Math.min(savedColumn, normalizedColumnCount - 1)
+        : blockIndex % normalizedColumnCount;
+      renderColumns[normalizedColumn].blocks.push(block);
+    });
+  }
 
   // Resize all textareas when component mounts
   onMount(() => {
@@ -366,6 +402,27 @@
 .container.focused {
   outline: 4px solid transparent;
 
+}
+
+.drag-handle {
+  align-self: flex-end;
+  border: 1px solid var(--text-color);
+  background: transparent;
+  color: var(--text-color);
+  border-radius: 8px;
+  padding: 3px 7px;
+  cursor: grab;
+  margin-bottom: 4px;
+}
+
+.drop-slot {
+  height: 12px;
+  border-radius: 8px;
+  margin: 2px 0;
+}
+
+.drop-slot:hover {
+  background: color-mix(in srgb, var(--mode-text-color) 22%, transparent);
 }
 
 textarea {
@@ -534,8 +591,13 @@ li {
 
 <div class="simple-wrapper" bind:this={canvasRef} style={`${canvasCssVars} --simple-note-columns: ${normalizedColumnCount};`}>
   {#each renderColumns as column}
-    <div class="simple-column">
-      {#each column as block (blockKey(block))}
+    <div
+      class="simple-column"
+      on:dragover={handleDragOver}
+      on:drop={(event) => handleDrop(event, null, column.columnIndex, 'end')}
+    >
+      {#each column.blocks as block (blockKey(block))}
+      <div class="drop-slot" on:dragover={handleDragOver} on:drop={(event) => handleDrop(event, block.id, column.columnIndex, 'before')}></div>
       <div class="canvas">
         <div
           class="container"
@@ -552,6 +614,16 @@ li {
           aria-pressed={block.id === focusedBlockId}
           on:keydown={(event) => handleBlockKeydown(event, block.id)}
         >
+          <button
+            class="drag-handle"
+            draggable="true"
+            on:dragstart={(event) => handleDragStart(event, block.id)}
+            on:dragend={handleDragEnd}
+            data-focus-guard
+            aria-label="Drag block"
+          >
+            ↕ Drag
+          </button>
           {#if block.type === 'text' || block.type === 'cleantext'}
             <textarea
               bind:value={block.content}
@@ -641,6 +713,7 @@ li {
         </div>
       </div>
       {/each}
+      <div class="drop-slot" on:dragover={handleDragOver} on:drop={(event) => handleDrop(event, null, column.columnIndex, 'endInColumn')}></div>
     </div>
   {/each}
 </div>


### PR DESCRIPTION
### Motivation
- Preserve user-configured simple-mode column layout across sessions and enable intuitive reordering of notes within/between columns.
- Support redistributing blocks when the simple column count changes to maintain a sensible layout and backup state.

### Description
- Added persistent storage for mode settings using `MODE_SETTINGS_STORAGE_KEY` with `loadStoredModeSettings` and `persistModeSettings`, and initialized `modeSettings` from stored data.
- Updated `handleModeSettingChange` to persist mode settings and, when `columnCount` changes, redistribute blocks into new columns then call `pushHistory` and `persistAutosave` with the updated layout.
- Implemented a `handleSimpleModeReorder` handler in the main app to update `modeOrders` and block `simpleColumn` values, and to push history after reorder actions; wired event dispatching through `ModeSwitcher`/`ModeArea` to the `SimpleNoteMode` component.
- Enhanced `SimpleNoteMode` with drag-and-drop UI: drag handle, drop slots, drag event handlers (`handleDragStart`, `handleDragOver`, `handleDrop`, `handleDragEnd`), column rendering based on `block.simpleColumn`, and styling for drag handles and drop slots.

### Testing
- Ran the project build with `npm run build`, which completed successfully.
- Ran the automated test suite with `npm test`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f680c087e8832e935645c5500a3ee4)