### PR TITLE
Persist SimpleNote column count and enable drag block ordering

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -155,15 +155,29 @@
       columnCount: 2
     }
   };
+  const SIMPLE_NOTE_COLUMN_STORAGE_KEY = 'simpleNoteColumnCount';
+
+  function loadStoredSimpleNoteColumnCount() {
+    if (typeof localStorage === 'undefined') return DEFAULT_MODE_SETTINGS.simple.columnCount;
+    const parsed = Number.parseInt(localStorage.getItem(SIMPLE_NOTE_COLUMN_STORAGE_KEY), 10);
+    return Math.max(1, Number.isFinite(parsed) ? parsed : DEFAULT_MODE_SETTINGS.simple.columnCount);
+  }
+
+  function persistSimpleNoteColumnCount(columnCount) {
+    if (typeof localStorage === 'undefined') return;
+    const normalized = Math.max(1, Number.parseInt(columnCount, 10) || DEFAULT_MODE_SETTINGS.simple.columnCount);
+    localStorage.setItem(SIMPLE_NOTE_COLUMN_STORAGE_KEY, String(normalized));
+  }
 
   function normalizeModeSettings(settings) {
     const incomingSimple = settings?.simple || {};
+    const storedColumnCount = loadStoredSimpleNoteColumnCount();
     return {
       ...DEFAULT_MODE_SETTINGS,
       simple: {
         ...DEFAULT_MODE_SETTINGS.simple,
         ...incomingSimple,
-        columnCount: Math.max(1, Number.parseInt(incomingSimple.columnCount, 10) || DEFAULT_MODE_SETTINGS.simple.columnCount)
+        columnCount: Math.max(1, Number.parseInt(incomingSimple.columnCount, 10) || storedColumnCount)
       }
     };
   }
@@ -1455,7 +1469,28 @@
       }
     });
     modeSettings = nextModeSettings;
+    persistSimpleNoteColumnCount(nextColumnCount);
     await persistAutosave(blocks, modeOrders, nextModeSettings);
+  }
+
+  async function handleSimpleBlockReorder(event) {
+    const draggedId = event.detail?.draggedId;
+    const targetId = event.detail?.targetId;
+    if (!draggedId || !targetId || draggedId === targetId) return;
+
+    const ordersForMode = [...(normalizedModeOrders[mode] || [])];
+    const fromIndex = ordersForMode.indexOf(draggedId);
+    const toIndex = ordersForMode.indexOf(targetId);
+    if (fromIndex === -1 || toIndex === -1) return;
+
+    ordersForMode.splice(fromIndex, 1);
+    ordersForMode.splice(toIndex, 0, draggedId);
+
+    modeOrders = {
+      ...modeOrders,
+      [mode]: ordersForMode
+    };
+    await pushHistory(blocks, modeOrders);
   }
 
   function setupControlsObserver() {
@@ -1849,6 +1884,7 @@
       on:delete={deleteBlockHandler}
       on:focusToggle={handleFocusToggle}
       on:modeSettingChange={handleModeSettingChange}
+      on:reorderBlocks={handleSimpleBlockReorder}
     />
   </div>
 </div>

--- a/src/Modes/SimpleNoteMode.svelte
+++ b/src/Modes/SimpleNoteMode.svelte
@@ -263,6 +263,31 @@
     }
   }
 
+  let draggedBlockId = null;
+
+  function handleBlockDragStart(event, blockId) {
+    draggedBlockId = blockId;
+    event.dataTransfer?.setData('text/plain', blockId);
+    if (event.dataTransfer) event.dataTransfer.effectAllowed = 'move';
+    ensureFocus(blockId);
+  }
+
+  function handleBlockDragOver(event) {
+    event.preventDefault();
+    if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+  }
+
+  function handleBlockDrop(event, targetBlockId) {
+    event.preventDefault();
+    const draggedId = draggedBlockId || event.dataTransfer?.getData('text/plain');
+    if (!draggedId || draggedId === targetBlockId) return;
+    dispatch('reorderBlocks', { draggedId, targetId: targetBlockId });
+  }
+
+  function handleBlockDragEnd() {
+    draggedBlockId = null;
+  }
+
   $: normalizedColumnCount = Math.max(1, Number.parseInt(columnCount, 10) || 2);
   $: renderColumns = Array.from({ length: normalizedColumnCount }, (_, columnIndex) =>
     blocks.filter((_, blockIndex) => blockIndex % normalizedColumnCount === columnIndex)
@@ -551,6 +576,11 @@ li {
           tabindex="0"
           aria-pressed={block.id === focusedBlockId}
           on:keydown={(event) => handleBlockKeydown(event, block.id)}
+          draggable="true"
+          on:dragstart={(event) => handleBlockDragStart(event, block.id)}
+          on:dragover={handleBlockDragOver}
+          on:drop={(event) => handleBlockDrop(event, block.id)}
+          on:dragend={handleBlockDragEnd}
         >
           {#if block.type === 'text' || block.type === 'cleantext'}
             <textarea


### PR DESCRIPTION
### Motivation
- Remember the user's SimpleNote column count across refreshes so the layout doesn't reset after reloads.
- Allow reordering blocks by dragging so users can arrange content visually in SimpleNote mode.
- Preserve the existing column distribution logic (modulo-based balancing) when the column count changes.

### Description
- Added localStorage helpers `SIMPLE_NOTE_COLUMN_STORAGE_KEY`, `loadStoredSimpleNoteColumnCount()` and `persistSimpleNoteColumnCount()` and used them as a fallback in `normalizeModeSettings()` in `src/App.svelte`.
- Persist the selected column count whenever mode settings change by calling `persistSimpleNoteColumnCount()` from `handleModeSettingChange()` in `src/App.svelte`.
- Implemented `handleSimpleBlockReorder()` in `src/App.svelte` to update `modeOrders` and push history/autosave when blocks are reordered.
- Made SimpleNote blocks draggable in `src/Modes/SimpleNoteMode.svelte` and dispatch a `reorderBlocks` event on drop, while keeping the original `renderColumns` (`index % columnCount`) balancing logic unchanged.

### Testing
- Ran `npm run build` and the build completed successfully with no errors.
- The build produced existing, unrelated Svelte/Vite warnings (a11y and unused selector), but they are pre-existing and did not cause the build to fail.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6879970a0832ebc707c2360b9931e)