### PR TITLE
Add background cloud sync with attachment upload control and bootstrap merge

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -823,6 +823,12 @@
   let birthdayUnlockMessage = "";
   let deferredLastSaveName = '';
   let deferredLastSaveReason = '';
+  let cloudSyncTimeoutId = null;
+  let cloudSyncInFlight = false;
+  let cloudSyncPending = false;
+  let cloudNeedsAttachmentUpload = false;
+  let cloudBootstrapInProgress = false;
+  let cloudBootstrapComplete = false;
   $: birthdayModeUnlocked = birthdayUnlockExpiry > Date.now();
 
   // --- Undo/Redo history ---
@@ -865,6 +871,67 @@
       modeSettings: normalizeModeSettings(settingsToPersist)
     });
     savedList = await listSavedBlocks();
+    scheduleCloudSync();
+  }
+
+  function markCloudAttachmentDirty() {
+    cloudNeedsAttachmentUpload = true;
+  }
+
+  function scheduleCloudSync() {
+    if (!firebaseReady || !currentSaveName) return;
+    cloudSyncPending = true;
+    if (cloudSyncTimeoutId !== null) return;
+    cloudSyncTimeoutId = window.setTimeout(() => {
+      cloudSyncTimeoutId = null;
+      syncCurrentFileToCloud();
+    }, 10_000);
+  }
+
+  async function syncCurrentFileToCloud() {
+    if (cloudSyncInFlight || !cloudSyncPending) return;
+    if (!firebaseReady || !currentSaveName) return;
+    if (!authUser) {
+      if (cloudSyncTimeoutId === null) {
+        cloudSyncTimeoutId = window.setTimeout(() => {
+          cloudSyncTimeoutId = null;
+          syncCurrentFileToCloud();
+        }, 10_000);
+      }
+      return;
+    }
+    if (cloudBootstrapInProgress) {
+      if (cloudSyncTimeoutId === null) {
+        cloudSyncTimeoutId = window.setTimeout(() => {
+          cloudSyncTimeoutId = null;
+          syncCurrentFileToCloud();
+        }, 10_000);
+      }
+      return;
+    }
+
+    cloudSyncInFlight = true;
+    cloudSyncPending = false;
+    const shouldUploadAttachments = cloudNeedsAttachmentUpload;
+    cloudNeedsAttachmentUpload = false;
+
+    try {
+      const payload = normalizeLoadedData(await loadBlocks(currentSaveName), currentSaveName);
+      await saveRemoteFile(currentSaveName, payload, {
+        uploadAttachments: shouldUploadAttachments
+      });
+    } catch (error) {
+      console.error('Auto cloud sync failed:', error);
+      cloudSyncPending = true;
+    } finally {
+      cloudSyncInFlight = false;
+      if (cloudSyncPending && cloudSyncTimeoutId === null) {
+        cloudSyncTimeoutId = window.setTimeout(() => {
+          cloudSyncTimeoutId = null;
+          syncCurrentFileToCloud();
+        }, 10_000);
+      }
+    }
   }
 
   async function pushHistory(newBlocks, newOrders = modeOrders) {
@@ -1004,6 +1071,7 @@
 
   function deleteBlockHandler(event) {
     const id = event.detail?.id;
+    const deletingBlock = blocks.find(block => block.id === id);
     blocks = blocks.filter(b => b.id !== id);
     modeOrders = ensureModeOrders(
       blocks,
@@ -1016,6 +1084,9 @@
     );
     if (focusedBlockId === id) {
       focusedBlockId = null;
+    }
+    if (deletingBlock?.type === 'image') {
+      markCloudAttachmentDirty();
     }
     pushHistory(blocks, modeOrders);
   }
@@ -1053,6 +1124,9 @@
 
     if (!actualChangedKeys.length) {
       return;
+    }
+    if (existing.type === 'image' && actualChangedKeys.includes('src')) {
+      markCloudAttachmentDirty();
     }
 
     let shouldSnapshot;
@@ -1123,6 +1197,7 @@
 
     blocks = [...blocks, mediaBlock];
     modeOrders = ensureModeOrders(blocks, modeOrders);
+    markCloudAttachmentDirty();
     await pushHistory(blocks, modeOrders);
   }
 
@@ -1282,6 +1357,7 @@
 
     try {
       await signInWithGoogle();
+      await bootstrapCloudSync();
     } catch (error) {
       console.error(error);
       alert(`Google sign-in failed: ${error?.message || error}`);
@@ -1363,6 +1439,55 @@
       alert(`Download failed: ${error?.message || error}`);
     } finally {
       downloadInProgress = false;
+    }
+  }
+
+  async function bootstrapCloudSync() {
+    if (!firebaseReady || !authUser) return;
+    if (cloudBootstrapInProgress) return;
+
+    cloudBootstrapInProgress = true;
+    try {
+      const [localNames, remoteIndex] = await Promise.all([
+        listSavedBlocks(),
+        loadRemoteIndex()
+      ]);
+      const remoteNames = Object.keys(remoteIndex || {});
+      const localNameSet = new Set(localNames);
+      const remoteNameSet = new Set(remoteNames);
+
+      for (const remoteName of remoteNames) {
+        const remoteMeta = remoteIndex?.[remoteName] || {};
+        const localPayload = localNameSet.has(remoteName)
+          ? await loadBlocks(remoteName)
+          : null;
+        const localUpdatedAt = Number(localPayload?.updatedAt || 0);
+        const remoteUpdatedAt = Number(remoteMeta?.updatedAt || 0);
+
+        if (!localPayload || remoteUpdatedAt > localUpdatedAt) {
+          const remotePayload = await loadRemoteFile(remoteName);
+          if (remotePayload) {
+            await saveBlocks(remoteName, remotePayload);
+          }
+        }
+      }
+
+      for (const localName of localNames) {
+        if (remoteNameSet.has(localName)) continue;
+        const localPayload = await loadBlocks(localName);
+        await saveRemoteFile(localName, localPayload, { uploadAttachments: true });
+      }
+
+      savedList = await listSavedBlocks();
+      cloudBootstrapComplete = true;
+      scheduleCloudSync();
+    } catch (error) {
+      console.error('Cloud bootstrap sync failed:', error);
+      // Do not block regular autosync forever if bootstrap fails.
+      cloudBootstrapComplete = true;
+      scheduleCloudSync();
+    } finally {
+      cloudBootstrapInProgress = false;
     }
   }
 
@@ -1651,7 +1776,19 @@
     controlsResizeObserver?.disconnect();
     observedControlsEl = null;
     stopAuthListener?.();
+    if (cloudSyncTimeoutId !== null) {
+      window.clearTimeout(cloudSyncTimeoutId);
+      cloudSyncTimeoutId = null;
+    }
   });
+
+  $: if (firebaseReady && authUser && !cloudBootstrapComplete && !cloudBootstrapInProgress) {
+    bootstrapCloudSync();
+  }
+
+  $: if (!authUser) {
+    cloudBootstrapComplete = false;
+  }
 
   $: if (controlsRef) {
     setupControlsObserver();

--- a/src/firebaseClient.js
+++ b/src/firebaseClient.js
@@ -181,11 +181,14 @@ export async function loadRemoteIndex() {
   return snapshot.exists() ? snapshot.val() : {};
 }
 
-export async function saveRemoteFile(fileId, payload) {
+export async function saveRemoteFile(fileId, payload, options = {}) {
   if (!isFirebaseConfigured()) return null;
   const ctx = await getFirebaseContext();
   const user = requireUser(ctx.auth.currentUser);
-  const payloadWithRemoteAttachments = await uploadBlockAttachments(fileId, payload, ctx, user.uid);
+  const shouldUploadAttachments = options.uploadAttachments !== false;
+  const payloadWithRemoteAttachments = shouldUploadAttachments
+    ? await uploadBlockAttachments(fileId, payload, ctx, user.uid)
+    : payload;
   const updatedAt = payload?.updatedAt || Date.now();
 
   await ctx.dbApi.set(


### PR DESCRIPTION
### Motivation

- Keep local save files automatically synced to Firebase in the background to ensure remote backups and multi-device availability.
- Avoid unnecessary re-uploads of large media attachments by tracking when attachments change and only uploading them when needed.
- Provide a bootstrap/merge step on sign-in to reconcile local and remote saves and ensure the most recent versions are present locally or remotely.

### Description

- Introduces cloud sync state and scheduling in `App.svelte` including `cloudSyncTimeoutId`, `cloudSyncInFlight`, `cloudSyncPending`, `cloudNeedsAttachmentUpload`, `cloudBootstrapInProgress`, and `cloudBootstrapComplete` and implements `scheduleCloudSync`, `syncCurrentFileToCloud`, and `bootstrapCloudSync` functions.
- Marks attachment state dirty via `markCloudAttachmentDirty()` when image blocks are added, deleted, or their `src` is changed, and triggers scheduled sync from `persistAutosave` and history push paths.
- Adds reactive hooks to start `bootstrapCloudSync` after authentication and to clear pending timeouts on destroy so sync timers are cleaned up properly.
- Updates Firebase client `saveRemoteFile` signature to accept `options` and conditionally skip uploading attachments when `options.uploadAttachments` is `false` to prevent redundant media uploads during routine autosyncs.

### Testing

- Ran the project test suite with `npm test` and the tests completed successfully with no regressions.
- Ran the linter with `npm run lint` and automatic checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f688d4e0a8832ea9c4fa36d2132296)