### PR TITLE
Split auto-sync into separate upload/download ticks and add remote pull handling

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -828,10 +828,12 @@
   let cloudBootstrapInProgress = false;
   let cloudBootstrapComplete = false;
   let autoSyncEnabled = true;
-  let autoSyncIntervalId = null;
+  let autoSyncDownloadIntervalId = null;
+  let autoSyncUploadIntervalId = null;
   let autoSyncDirty = false;
   let lastAutoSyncFingerprint = '';
   let lastAutoSyncAttachmentFingerprint = '';
+  let lastRemoteSyncFingerprint = '';
   $: birthdayModeUnlocked = birthdayUnlockExpiry > Date.now();
 
   // --- Undo/Redo history ---
@@ -1392,7 +1394,57 @@
     return { fingerprint, attachmentFingerprint };
   }
 
-  async function autoSyncTick() {
+
+  async function remountCurrentSaveIfLoaded() {
+    if (!currentSaveName || !savedList.includes(currentSaveName)) return;
+    await load(currentSaveName);
+  }
+
+  async function pullRemoteUpdatesIfNeeded(options = {}) {
+    if (!autoSyncEnabled || !firebaseReady || !authUser || uploadInProgress || cloudBootstrapInProgress) return false;
+
+    const remoteIndex = await loadRemoteIndex();
+    const remoteEntries = Object.entries(remoteIndex || {});
+    const remoteFingerprint = remoteEntries
+      .map(([fileName, meta]) => `${fileName}:${Number(meta?.updatedAt || 0)}`)
+      .sort()
+      .join('|');
+
+    if (remoteFingerprint === lastRemoteSyncFingerprint) return false;
+
+    let downloadedAny = false;
+    for (const [fileName, remoteMeta] of remoteEntries) {
+      const localPayload = savedList.includes(fileName) ? await loadBlocks(fileName) : null;
+      const localUpdatedAt = Number(localPayload?.updatedAt || 0);
+      const remoteUpdatedAt = Number(remoteMeta?.updatedAt || 0);
+
+      if (!localPayload || remoteUpdatedAt > localUpdatedAt) {
+        const remotePayload = await loadRemoteFile(fileName);
+        if (!remotePayload) continue;
+        await saveBlocks(fileName, remotePayload);
+        downloadedAny = true;
+      }
+    }
+
+    lastRemoteSyncFingerprint = remoteFingerprint;
+
+    if (downloadedAny) {
+      savedList = await listSavedBlocks();
+      await remountCurrentSaveIfLoaded();
+      if (options.showInfo) {
+        alert('Cloud download complete. Newer cloud updates were applied.');
+      }
+    }
+
+    return downloadedAny;
+  }
+
+  async function autoSyncDownloadTick() {
+    if (!autoSyncEnabled || !firebaseReady || !authUser || uploadInProgress || cloudBootstrapInProgress) return;
+    await pullRemoteUpdatesIfNeeded();
+  }
+
+  async function autoSyncUploadTick() {
     if (!autoSyncEnabled || !firebaseReady || !authUser || uploadInProgress || cloudBootstrapInProgress) return;
     if (!autoSyncDirty) return;
     const { fingerprint, attachmentFingerprint } = await buildLocalSyncFingerprint();
@@ -1427,19 +1479,7 @@
 
     downloadInProgress = true;
     try {
-      const remoteIndex = await loadRemoteIndex();
-      const remoteNames = Object.keys(remoteIndex || {});
-      let downloadedCount = 0;
-
-      for (const fileName of remoteNames) {
-        const remotePayload = await loadRemoteFile(fileName);
-        if (!remotePayload) continue;
-        await saveBlocks(fileName, remotePayload);
-        downloadedCount += 1;
-      }
-
-      savedList = await listSavedBlocks();
-      alert(`Download complete. Downloaded ${downloadedCount} save file(s).`);
+      await pullRemoteUpdatesIfNeeded({ showInfo: true });
     } catch (error) {
       console.error(error);
       alert(`Download failed: ${error?.message || error}`);
@@ -1774,14 +1814,24 @@
       persistLastSaveName(currentSaveName);
     }
 
-    autoSyncIntervalId = window.setInterval(() => {
-      autoSyncTick().catch(error => {
-        console.error('Auto sync tick failed:', error);
+    autoSyncDownloadIntervalId = window.setInterval(() => {
+      autoSyncDownloadTick().catch(error => {
+        console.error('Auto sync download tick failed:', error);
+      });
+    }, 1_000);
+
+    autoSyncUploadIntervalId = window.setInterval(() => {
+      autoSyncUploadTick().catch(error => {
+        console.error('Auto sync upload tick failed:', error);
       });
     }, 10_000);
 
-    autoSyncTick().catch(error => {
-      console.error('Initial auto sync tick failed:', error);
+    autoSyncDownloadTick().catch(error => {
+      console.error('Initial auto sync download tick failed:', error);
+    });
+
+    autoSyncUploadTick().catch(error => {
+      console.error('Initial auto sync upload tick failed:', error);
     });
   });
 
@@ -1791,9 +1841,13 @@
     controlsResizeObserver?.disconnect();
     observedControlsEl = null;
     stopAuthListener?.();
-    if (autoSyncIntervalId !== null) {
-      window.clearInterval(autoSyncIntervalId);
-      autoSyncIntervalId = null;
+    if (autoSyncDownloadIntervalId !== null) {
+      window.clearInterval(autoSyncDownloadIntervalId);
+      autoSyncDownloadIntervalId = null;
+    }
+    if (autoSyncUploadIntervalId !== null) {
+      window.clearInterval(autoSyncUploadIntervalId);
+      autoSyncUploadIntervalId = null;
     }
   });
 


### PR DESCRIPTION
### Motivation

- Reduce missed updates and make cloud sync more robust by separating upload and download responsibilities and detecting remote-only updates.
- Ensure the UI remounts the currently open save if a newer cloud copy is pulled down.

### Description

- Introduced `remountCurrentSaveIfLoaded` and `pullRemoteUpdatesIfNeeded` to detect and apply newer remote saves and track a `lastRemoteSyncFingerprint` for change detection.
- Split the previous single `autoSyncTick` into `autoSyncDownloadTick` and `autoSyncUploadTick`, added separate interval IDs `autoSyncDownloadIntervalId` and `autoSyncUploadIntervalId`, and set distinct intervals for download and upload ticks.`
- Updated `downloadAllCloudToLocal` to delegate to `pullRemoteUpdatesIfNeeded` and added logic to remount and refresh `savedList` when downloads occur.
- Adjusted cleanup in `onDestroy` to clear both new interval IDs and added initial invocations and error logging for both upload and download ticks.

### Testing

- Ran the project's automated test suite with `npm test` and a development build with `npm run build`, and both completed successfully.
- Verified the auto-sync routines start and stop via the created intervals in a local smoke test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a2d49e84832ea74afbb25988e8d0)