### PR TITLE
Fix canvas text block scroll resetting after other block edits

### DIFF
--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -376,7 +376,7 @@
         style:background={canvasTheme.innerBg || defaultCanvasColors.innerBg}
       >
       <div class="canvas-content" style:transform={`translateX(${contentOffsetX}px)`}>
-      {#each blocks as block (`${block.id}-${block._version || 0}`)}
+      {#each blocks as block (block.id)}
         {#if block.type === 'text'}
           <TexteBlock
             id={block.id}


### PR DESCRIPTION
### Motivation
- Svelte was remounting canvas block components when their key changed, which caused internal UI state like text scroll position to reset.
- The key included `_version`, so unrelated updates (move/resize of other blocks) changed keys and recreated components.

### Description
- Use a stable key for the `#each` loop by switching from ``{#each blocks as block (`${block.id}-${block._version || 0}`)}`` to ``{#each blocks as block (block.id)}`` in `src/Modes/CanvasMode.svelte`.
- This keeps block component instances (e.g. `TexteBlock` / `TexteClean`) mounted across unrelated updates so local state is preserved.

### Testing
- Ran `npm run build` and the build completed successfully with only pre-existing Svelte/Vite warnings reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a78b62bc832eab87571c6d0dc3f6)