### PR TITLE
Persist and restore text block scroll positions

### DIFF
--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -385,6 +385,7 @@
             initialBgColor={block.bgColor}
             initialTextColor={block.textColor}
             initialContent={block.content}
+            initialScrollTop={block.scrollTop}
             focused={block.id === focusedBlockId}
             canvasScale={scale}
             on:delete={deleteBlockHandler}
@@ -416,6 +417,7 @@
             initialBgColor={block.bgColor}
             initialTextColor={block.textColor}
             initialContent={block.content}
+            initialScrollTop={block.scrollTop}
             focused={block.id === focusedBlockId}
             canvasScale={scale}
             on:delete={deleteBlockHandler}

--- a/src/components/TexteBlock.svelte
+++ b/src/components/TexteBlock.svelte
@@ -7,6 +7,7 @@
   export let initialBgColor = '#000000';
   export let initialTextColor = '#ffffff';
   export let initialContent = '';
+  export let initialScrollTop = 0;
   export let focused = false;
   export let canvasScale = 1;
 
@@ -17,6 +18,7 @@
   let bgColor = initialBgColor;
   let textColor = initialTextColor;
   let content = initialContent;
+  let textareaEl;
 
   let dragging = false;
   let resizing = false;
@@ -37,7 +39,7 @@
 
   function sendUpdate(changedKeys, { pushToHistory } = {}) {
     const effectiveKeys = Array.isArray(changedKeys) && changedKeys.length ? changedKeys : [];
-    const detail = { id, position, size, bgColor, textColor, content };
+    const detail = { id, position, size, bgColor, textColor, content, scrollTop: textareaEl?.scrollTop ?? 0 };
 
     if (effectiveKeys.length) detail.changedKeys = effectiveKeys;
     if (pushToHistory !== undefined) detail.pushToHistory = pushToHistory;
@@ -186,6 +188,21 @@
     event.preventDefault();
     handleWrapperClick(event);
   }
+
+  function applySavedScroll() {
+    if (!textareaEl) return;
+    const nextScrollTop = Number(initialScrollTop ?? 0);
+    textareaEl.scrollTop = Number.isFinite(nextScrollTop) ? Math.max(0, nextScrollTop) : 0;
+  }
+
+  function handleTextScroll() {
+    if (!textareaEl) return;
+    sendUpdate(['scrollTop'], { pushToHistory: false });
+  }
+
+  $: if (textareaEl) {
+    applySavedScroll();
+  }
 </script>
 
 <style>
@@ -325,9 +342,11 @@
 
   <div class="text-container">
     <textarea
+      bind:this={textareaEl}
       spellcheck="false"
       bind:value={content}
       on:input={() => sendUpdate(['content'], { pushToHistory: false })}
+      on:scroll={handleTextScroll}
       on:focus={ensureFocus}
       data-focus-guard
     ></textarea>

--- a/src/components/TexteClean.svelte
+++ b/src/components/TexteClean.svelte
@@ -7,6 +7,7 @@
   export let initialBgColor = '#ffffff';
   export let initialTextColor = '#000000';
   export let initialContent = '';
+  export let initialScrollTop = 0;
   export let focused = false;
   export let canvasScale = 1;
 
@@ -44,7 +45,7 @@
     content = editableDiv?.innerText ?? content;
 
     const effectiveKeys = Array.isArray(changedKeys) && changedKeys.length ? changedKeys : [];
-    const detail = { id, position, size, bgColor, textColor, content };
+    const detail = { id, position, size, bgColor, textColor, content, scrollTop: editableDiv?.scrollTop ?? 0 };
 
     if (effectiveKeys.length) detail.changedKeys = effectiveKeys;
     if (pushToHistory !== undefined) detail.pushToHistory = pushToHistory;
@@ -188,6 +189,21 @@
 
     event.preventDefault();
     handleWrapperClick(event);
+  }
+
+  function applySavedScroll() {
+    if (!editableDiv) return;
+    const nextScrollTop = Number(initialScrollTop ?? 0);
+    editableDiv.scrollTop = Number.isFinite(nextScrollTop) ? Math.max(0, nextScrollTop) : 0;
+  }
+
+  function handleEditableScroll() {
+    if (!editableDiv) return;
+    sendUpdate(['scrollTop'], { pushToHistory: false });
+  }
+
+  $: if (editableDiv) {
+    applySavedScroll();
   }
 </script>
 
@@ -346,6 +362,7 @@
     class="editable"
     spellcheck="false"
     on:input={() => sendUpdate(['content'], { pushToHistory: false })}
+    on:scroll={handleEditableScroll}
     on:focus={ensureFocus}
     data-focus-guard
   ></div>


### PR DESCRIPTION
### Motivation
- Ensure text-like blocks retain and restore their vertical scroll position when re-rendered or when switching focus so users don't lose place while editing. 
- Include scroll position in block update events so the canvas can persist and synchronize scroll state across sessions or collaborators. 

### Description
- Pass `initialScrollTop={block.scrollTop}` for `text` and `cleantext` block renderings in `CanvasMode.svelte`. 
- Add `initialScrollTop` prop and element refs (`textareaEl` / `editableDiv`) to `TexteBlock.svelte` and `TexteClean.svelte`, apply saved scroll with `applySavedScroll`, and call it reactively when the element becomes available. 
- Include `scrollTop` in `sendUpdate` payloads and wire `on:scroll` handlers (`handleTextScroll` / `handleEditableScroll`) to dispatch scroll updates without pushing to history. 

### Testing
- Ran unit tests with `npm test` and they passed. 
- Ran the build with `npm run build` and it completed successfully. 
- Ran linting with `npm run lint` and no issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a78b62bc832eab87571c6d0dc3f6)