### PR TITLE
Refactor Firebase sync to use RTDB metadata + Cloud Storage snapshots

### DIFF
--- a/src/firebaseClient.js
+++ b/src/firebaseClient.js
@@ -162,11 +162,28 @@ export async function loadRemoteFile(fileId) {
   const ctx = await getFirebaseContext();
   const user = requireUser(ctx.auth.currentUser);
 
-  const snapshot = await ctx.dbApi.get(
+  const metadataSnapshot = await ctx.dbApi.get(
     ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `files/${fileId}`))
   );
 
-  return snapshot.exists() ? snapshot.val() : null;
+  if (!metadataSnapshot.exists()) return null;
+  const metadata = metadataSnapshot.val() || {};
+  if (!metadata.storagePath) return null;
+
+  const storageRef = ctx.storageApi.ref(ctx.storage, metadata.storagePath);
+  const downloadUrl = await ctx.storageApi.getDownloadURL(storageRef);
+  const response = await fetch(downloadUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch remote file snapshot for ${fileId}.`);
+  }
+
+  const payload = await response.json();
+  return {
+    ...payload,
+    updatedAt: metadata.updatedAt || payload?.updatedAt || null,
+    version: metadata.version || payload?.version || null,
+    _remoteMeta: metadata
+  };
 }
 
 export async function loadRemoteIndex() {
@@ -190,22 +207,54 @@ export async function saveRemoteFile(fileId, payload, options = {}) {
     ? await uploadBlockAttachments(fileId, payload, ctx, user.uid)
     : payload;
   const updatedAt = payload?.updatedAt || Date.now();
+  const version = Number(payload?.version) || 1;
+  const storagePath = getStorageUserPath(user.uid, `files/${fileId}/latest.json`);
+  const payloadSnapshot = {
+    ...payloadWithRemoteAttachments,
+    fileId,
+    updatedAt,
+    version
+  };
 
-  await ctx.dbApi.set(
-    ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `files/${fileId}`)),
-    { ...payloadWithRemoteAttachments, updatedAt }
-  );
+  const payloadText = JSON.stringify(payloadSnapshot);
+  const payloadSize = new Blob([payloadText]).size;
+  const storageRef = ctx.storageApi.ref(ctx.storage, storagePath);
+
+  await ctx.storageApi.uploadString(storageRef, payloadText, 'raw', {
+    contentType: 'application/json',
+    cacheControl: 'no-cache'
+  });
 
   await ctx.dbApi.set(
     ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `index/${fileId}`)),
     {
       fileId,
       updatedAt,
-      blockCount: Array.isArray(payloadWithRemoteAttachments?.blocks) ? payloadWithRemoteAttachments.blocks.length : 0
+      version,
+      storagePath,
+      size: payloadSize,
+      status: 'uploaded',
+      blockCount: Array.isArray(payloadWithRemoteAttachments?.blocks) ? payloadWithRemoteAttachments.blocks.length : 0,
+      title: payloadWithRemoteAttachments?.title || null,
+      preview: payloadWithRemoteAttachments?.preview || null
     }
   );
 
-  return { fileId, updatedAt };
+  await ctx.dbApi.set(
+    ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `files/${fileId}`)),
+    {
+      fileId,
+      updatedAt,
+      version,
+      storagePath,
+      size: payloadSize,
+      status: 'uploaded',
+      title: payloadWithRemoteAttachments?.title || null,
+      preview: payloadWithRemoteAttachments?.preview || null
+    }
+  );
+
+  return { fileId, updatedAt, version, storagePath, size: payloadSize };
 }
 
 export async function deleteRemoteFile(fileId) {
@@ -215,7 +264,10 @@ export async function deleteRemoteFile(fileId) {
 
   await Promise.all([
     ctx.dbApi.remove(ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `files/${fileId}`))),
-    ctx.dbApi.remove(ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `index/${fileId}`)))
+    ctx.dbApi.remove(ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `index/${fileId}`))),
+    ctx.storageApi.deleteObject(
+      ctx.storageApi.ref(ctx.storage, getStorageUserPath(user.uid, `files/${fileId}/latest.json`))
+    ).catch(() => {})
   ]);
 
   return { fileId };


### PR DESCRIPTION
### Motivation
- Reduce Realtime Database payload size by storing only lightweight metadata in RTDB while keeping full file snapshots in Cloud Storage.
- Ensure attachments and images remain stored in Cloud Storage to avoid saving large base64 payloads in RTDB.
- Make remote loads fetch the authoritative JSON snapshot from Storage using a `storagePath` index entry to minimize DB bandwidth.

### Description
- `loadRemoteFile` now reads metadata from RTDB `files/{fileId}`, then downloads and parses the full JSON snapshot from Cloud Storage via the `storagePath` metadata field instead of returning full JSON from RTDB.
- `saveRemoteFile` now uploads a full snapshot to `users/{uid}/files/{fileId}/latest.json` and writes only metadata (`fileId`, `updatedAt`, `version`, `storagePath`, `size`, `status`, and optional `title`/`preview` and `blockCount`) to RTDB `index/{fileId}` and `files/{fileId}`.
- `deleteRemoteFile` removes RTDB metadata nodes and attempts to delete the `latest.json` snapshot from Cloud Storage.
- Attachment upload behavior in `uploadAttachmentFromDataUrl` remains Storage-first and unchanged, continuing to replace inline data URLs with storage URLs.

### Testing
- Ran build with `npm run build`, which completed successfully (Vite build succeeded).
- Build produced pre-existing Svelte warnings (unused CSS selector and a11y warnings) and chunk-size warnings but no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb30675e30832eb3917e35191d6e8a)