### PR TITLE
Require Ctrl key for canvas edge auto-pan

### DIFF
--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -222,7 +222,7 @@
 
   function updateEdgePanFromPointer(event) {
     if (!canvasRef) return;
-    if (scale <= getViewportScaleFloor()) {
+    if (!event.ctrlKey || scale <= getViewportScaleFloor()) {
       stopEdgePan();
       return;
     }


### PR DESCRIPTION
### Motivation
- Prevent unintended canvas edge auto-panning by making it active only when the Control key is intentionally held during pointer movement.

### Description
- Update `updateEdgePanFromPointer` in `src/Modes/CanvasMode.svelte` to check `event.ctrlKey` and call `stopEdgePan()` when Ctrl is not held or when `scale <= getViewportScaleFloor()`.

### Testing
- Ran `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb34ad1b20832e9199dbd5765e3f2f)