### PR TITLE
Track per-file modified/synced timestamps for cloud sync conflict resolution

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1413,7 +1413,7 @@
     const remoteIndex = await loadRemoteIndex();
     const remoteEntries = Object.entries(remoteIndex || {});
     const remoteFingerprint = remoteEntries
-      .map(([fileName, meta]) => `${fileName}:${Number(meta?.updatedAt || 0)}`)
+      .map(([fileName, meta]) => `${fileName}:${Number(meta?.modifiedAt || meta?.updatedAt || 0)}`)
       .sort()
       .join('|');
 
@@ -1422,10 +1422,10 @@
     let downloadedAny = false;
     for (const [fileName, remoteMeta] of remoteEntries) {
       const localPayload = savedList.includes(fileName) ? await loadBlocks(fileName) : null;
-      const localUpdatedAt = Number(localPayload?.updatedAt || 0);
-      const remoteUpdatedAt = Number(remoteMeta?.updatedAt || 0);
+      const localModifiedAt = Number(localPayload?.modifiedAt || localPayload?.updatedAt || 0);
+      const remoteModifiedAt = Number(remoteMeta?.modifiedAt || remoteMeta?.updatedAt || 0);
 
-      if (!localPayload || remoteUpdatedAt > localUpdatedAt) {
+      if (!localPayload || remoteModifiedAt > localModifiedAt) {
         const remotePayload = await loadRemoteFile(fileName);
         if (!remotePayload) continue;
         await saveBlocks(fileName, remotePayload);
@@ -1514,10 +1514,10 @@
         const localPayload = localNameSet.has(remoteName)
           ? await loadBlocks(remoteName)
           : null;
-        const localUpdatedAt = Number(localPayload?.updatedAt || 0);
-        const remoteUpdatedAt = Number(remoteMeta?.updatedAt || 0);
+        const localModifiedAt = Number(localPayload?.modifiedAt || localPayload?.updatedAt || 0);
+        const remoteModifiedAt = Number(remoteMeta?.modifiedAt || remoteMeta?.updatedAt || 0);
 
-        if (!localPayload || remoteUpdatedAt > localUpdatedAt) {
+        if (!localPayload || remoteModifiedAt > localModifiedAt) {
           const remotePayload = await loadRemoteFile(remoteName);
           if (remotePayload) {
             await saveBlocks(remoteName, remotePayload);

--- a/src/firebaseClient.js
+++ b/src/firebaseClient.js
@@ -190,10 +190,12 @@ export async function saveRemoteFile(fileId, payload, options = {}) {
     ? await uploadBlockAttachments(fileId, payload, ctx, user.uid)
     : payload;
   const updatedAt = payload?.updatedAt || Date.now();
+  const modifiedAt = payload?.modifiedAt || payload?.updatedAt || Date.now();
+  const lastSyncedAt = Date.now();
 
   await ctx.dbApi.set(
     ctx.dbApi.ref(ctx.db, getUserPath(user.uid, `files/${fileId}`)),
-    { ...payloadWithRemoteAttachments, updatedAt }
+    { ...payloadWithRemoteAttachments, updatedAt, modifiedAt, lastSyncedAt }
   );
 
   await ctx.dbApi.set(
@@ -201,6 +203,8 @@ export async function saveRemoteFile(fileId, payload, options = {}) {
     {
       fileId,
       updatedAt,
+      modifiedAt,
+      lastSyncedAt,
       blockCount: Array.isArray(payloadWithRemoteAttachments?.blocks) ? payloadWithRemoteAttachments.blocks.length : 0
     }
   );

--- a/src/storage.js
+++ b/src/storage.js
@@ -11,7 +11,8 @@ function asPayloadWithTimestamp(payload, updatedAt = Date.now()) {
     return {
       blocks: payload,
       modeOrders: {},
-      updatedAt
+      updatedAt,
+      modifiedAt: updatedAt
     };
   }
 
@@ -19,13 +20,16 @@ function asPayloadWithTimestamp(payload, updatedAt = Date.now()) {
     return {
       blocks: [],
       modeOrders: {},
-      updatedAt
+      updatedAt,
+      modifiedAt: updatedAt
     };
   }
 
+  const modifiedAt = payload.modifiedAt || payload.updatedAt || updatedAt;
   return {
     ...payload,
-    updatedAt: payload.updatedAt || updatedAt
+    updatedAt: payload.updatedAt || updatedAt,
+    modifiedAt
   };
 }
 


### PR DESCRIPTION
### Motivation
- Reduce sync conflicts by giving each saved file a comparable per-file last-modified timestamp in browser storage. 
- Ensure cloud vs local comparisons prefer the true last-modified moment instead of only `updatedAt` so newer edits are not overwritten. 
- Add sync metadata so the backend can record when a file was last synced to aid future conflict resolution and diagnostics.

### Description
- Normalize saved payloads in `src/storage.js` via `asPayloadWithTimestamp` to always include a `modifiedAt` field (falls back to `updatedAt`).
- Persist `modifiedAt` and `lastSyncedAt` to both the Firebase file record and the index entry in `src/firebaseClient.js` when calling `saveRemoteFile`.
- Update cloud sync logic in `src/App.svelte` (`pullRemoteUpdatesIfNeeded` and `bootstrapCloudSync`) to compare `modifiedAt` first with a fallback to `updatedAt`, and to build the remote fingerprint using `modifiedAt`.
- Keep backward compatibility by falling back to `updatedAt` when `modifiedAt` is not present.

### Testing
- Ran `npm run build` which completed successfully (build warnings reported by the Svelte toolchain but did not fail the build).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb3622f1a0832eb6557609dd98d03b)