### PR TITLE
Add cloud-sync conflict resolution, persistent per-file sync memory, and sync-lock UI

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -150,6 +150,7 @@
   const CONTROL_COLOR_STORAGE_KEY = 'controlColors';
   const LAST_SAVE_STORAGE_KEY = 'lastLoadedSave';
   const BOOT_LOAD_GUARD_STORAGE_KEY = 'bootLoadGuard';
+  const CLOUD_SYNC_MEMORY_STORAGE_KEY = 'cloudSyncMemoryByFile';
   const FALLBACK_SAVE_NAME = 'Fallback';
   const DEFAULT_MODE_SETTINGS = {
     simple: {
@@ -276,6 +277,26 @@
       localStorage.removeItem(BOOT_LOAD_GUARD_STORAGE_KEY);
     } catch (error) {
       /* ignore persistence failures */
+    }
+  }
+
+  function loadCloudSyncMemory() {
+    if (typeof localStorage === 'undefined') return {};
+    try {
+      const raw = localStorage.getItem(CLOUD_SYNC_MEMORY_STORAGE_KEY);
+      const parsed = raw ? JSON.parse(raw) : {};
+      return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+
+  function persistCloudSyncMemory(memory) {
+    if (typeof localStorage === 'undefined') return;
+    try {
+      localStorage.setItem(CLOUD_SYNC_MEMORY_STORAGE_KEY, JSON.stringify(memory || {}));
+    } catch {
+      /* ignore local persistence failure */
     }
   }
 
@@ -827,6 +848,10 @@
   let cloudNeedsAttachmentUpload = false;
   let cloudBootstrapInProgress = false;
   let cloudBootstrapComplete = false;
+  let cloudSyncGateInProgress = false;
+  let pendingSyncConflict = null;
+  let resolveConflictChoice = null;
+  let cloudSyncMemoryByFile = loadCloudSyncMemory();
   let autoSyncEnabled = true;
   let autoSyncDownloadIntervalId = null;
   let autoSyncUploadIntervalId = null;
@@ -835,6 +860,42 @@
   let lastAutoSyncAttachmentFingerprint = '';
   let lastRemoteSyncFingerprint = '';
   $: birthdayModeUnlocked = birthdayUnlockExpiry > Date.now();
+
+  function rememberCloudSyncForFile(fileName, syncedAt = Date.now()) {
+    cloudSyncMemoryByFile = {
+      ...cloudSyncMemoryByFile,
+      [fileName]: Number(syncedAt) || Date.now()
+    };
+    persistCloudSyncMemory(cloudSyncMemoryByFile);
+  }
+
+  async function saveRemoteFileWithMemory(fileName, payload, options = {}) {
+    const result = await saveRemoteFile(fileName, payload, options);
+    const syncedAt = Date.now();
+    rememberCloudSyncForFile(fileName, syncedAt);
+    return result;
+  }
+
+  async function askSyncConflictChoice(fileName, localModifiedAt, remoteModifiedAt, localLastSyncedAt = 0, remoteLastSyncedAt = 0) {
+    pendingSyncConflict = {
+      fileName,
+      localModifiedAt,
+      remoteModifiedAt,
+      localLastSyncedAt,
+      remoteLastSyncedAt
+    };
+    return await new Promise(resolve => {
+      resolveConflictChoice = resolve;
+    });
+  }
+
+  function chooseSyncConflict(option) {
+    if (!resolveConflictChoice) return;
+    const resolve = resolveConflictChoice;
+    resolveConflictChoice = null;
+    pendingSyncConflict = null;
+    resolve(option);
+  }
 
   // --- Undo/Redo history ---
   let history = [];
@@ -1352,7 +1413,7 @@
 
       for (const fileName of names) {
         const localPayload = await loadBlocks(fileName);
-        await saveRemoteFile(fileName, localPayload, {
+        await saveRemoteFileWithMemory(fileName, localPayload, {
           uploadAttachments
         });
         uploadedCount += 1;
@@ -1423,12 +1484,42 @@
     for (const [fileName, remoteMeta] of remoteEntries) {
       const localPayload = savedList.includes(fileName) ? await loadBlocks(fileName) : null;
       const localModifiedAt = Number(localPayload?.modifiedAt || localPayload?.updatedAt || 0);
+      const localUpdatedAt = Number(localPayload?.updatedAt || localPayload?.modifiedAt || 0);
       const remoteModifiedAt = Number(remoteMeta?.modifiedAt || remoteMeta?.updatedAt || 0);
+      const remoteUpdatedAt = Number(remoteMeta?.updatedAt || remoteMeta?.modifiedAt || 0);
+      const localLastSyncedAt = Number(cloudSyncMemoryByFile?.[fileName] || 0);
+      const remoteLastSyncedAt = Number(remoteMeta?.lastSyncedAt || 0);
 
       if (!localPayload || remoteModifiedAt > localModifiedAt) {
         const remotePayload = await loadRemoteFile(fileName);
         if (!remotePayload) continue;
+        const cloudClearlyNewer =
+          remoteModifiedAt > localModifiedAt &&
+          remoteUpdatedAt > localUpdatedAt &&
+          remoteLastSyncedAt >= localLastSyncedAt;
+
+        if (localPayload && localModifiedAt > 0 && remoteModifiedAt !== localModifiedAt && !cloudClearlyNewer) {
+          const normalizedDecision = await askSyncConflictChoice(fileName, localModifiedAt, remoteModifiedAt, localLastSyncedAt, remoteLastSyncedAt);
+          if (normalizedDecision === 'local') {
+            await saveRemoteFileWithMemory(fileName, localPayload, { uploadAttachments: true });
+            continue;
+          }
+          if (normalizedDecision === 'both') {
+            const localCloneName = `${fileName} (local ${new Date(localModifiedAt).toISOString().slice(0, 19).replace('T', ' ')})`;
+            const remoteCloneName = `${fileName} (cloud ${new Date(remoteModifiedAt).toISOString().slice(0, 19).replace('T', ' ')})`;
+            await saveBlocks(localCloneName, localPayload);
+            await saveRemoteFileWithMemory(localCloneName, localPayload, { uploadAttachments: true });
+            await saveBlocks(remoteCloneName, remotePayload);
+            await saveRemoteFileWithMemory(remoteCloneName, remotePayload, { uploadAttachments: true });
+            downloadedAny = true;
+            continue;
+          }
+          if (normalizedDecision === 'skip') {
+            continue;
+          }
+        }
         await saveBlocks(fileName, remotePayload);
+        await saveRemoteFileWithMemory(fileName, remotePayload, { uploadAttachments: true });
         downloadedAny = true;
       }
     }
@@ -1451,13 +1542,15 @@
     await pullRemoteUpdatesIfNeeded();
   }
 
-  async function autoSyncUploadTick() {
+  async function autoSyncUploadTick(options = {}) {
     if (!autoSyncEnabled || !firebaseReady || !authUser || uploadInProgress || cloudBootstrapInProgress) return;
-    if (!autoSyncDirty) return;
+    const force = options.force === true;
+    if (!autoSyncDirty && !force) return;
     const { fingerprint, attachmentFingerprint } = await buildLocalSyncFingerprint();
-    if (!fingerprint || fingerprint === lastAutoSyncFingerprint) return;
+    if (!fingerprint) return;
+    if (!force && fingerprint === lastAutoSyncFingerprint) return;
 
-    const attachmentsChanged = attachmentFingerprint !== lastAutoSyncAttachmentFingerprint;
+    const attachmentsChanged = force || attachmentFingerprint !== lastAutoSyncAttachmentFingerprint;
     await uploadAllLocalToCloud(false, {
       uploadAttachments: attachmentsChanged
     });
@@ -1467,8 +1560,27 @@
     autoSyncDirty = false;
   }
 
-  function toggleAutoSync() {
-    autoSyncEnabled = !autoSyncEnabled;
+  async function toggleAutoSync() {
+    if (autoSyncEnabled) {
+      autoSyncEnabled = false;
+      return;
+    }
+
+    if (!firebaseReady || !authUser) {
+      alert('Sign in with Google first.');
+      return;
+    }
+
+    cloudSyncGateInProgress = true;
+    try {
+      await bootstrapCloudSync({ interactiveConflictResolution: true });
+      autoSyncEnabled = true;
+      autoSyncDirty = true;
+      await pullRemoteUpdatesIfNeeded();
+      await autoSyncUploadTick({ force: true });
+    } finally {
+      cloudSyncGateInProgress = false;
+    }
   }
 
   async function downloadAllCloudToLocal() {
@@ -1495,7 +1607,7 @@
     }
   }
 
-  async function bootstrapCloudSync() {
+  async function bootstrapCloudSync(options = {}) {
     if (!firebaseReady || !authUser) return;
     if (cloudBootstrapInProgress) return;
 
@@ -1515,12 +1627,41 @@
           ? await loadBlocks(remoteName)
           : null;
         const localModifiedAt = Number(localPayload?.modifiedAt || localPayload?.updatedAt || 0);
+        const localUpdatedAt = Number(localPayload?.updatedAt || localPayload?.modifiedAt || 0);
         const remoteModifiedAt = Number(remoteMeta?.modifiedAt || remoteMeta?.updatedAt || 0);
+        const remoteUpdatedAt = Number(remoteMeta?.updatedAt || remoteMeta?.modifiedAt || 0);
+        const localLastSyncedAt = Number(cloudSyncMemoryByFile?.[remoteName] || 0);
+        const remoteLastSyncedAt = Number(remoteMeta?.lastSyncedAt || 0);
 
         if (!localPayload || remoteModifiedAt > localModifiedAt) {
           const remotePayload = await loadRemoteFile(remoteName);
           if (remotePayload) {
+            const cloudClearlyNewer =
+              remoteModifiedAt > localModifiedAt &&
+              remoteUpdatedAt > localUpdatedAt &&
+              remoteLastSyncedAt >= localLastSyncedAt;
+
+            if (options.interactiveConflictResolution && localPayload && localModifiedAt > 0 && remoteModifiedAt !== localModifiedAt && !cloudClearlyNewer) {
+              const normalizedDecision = await askSyncConflictChoice(remoteName, localModifiedAt, remoteModifiedAt, localLastSyncedAt, remoteLastSyncedAt);
+              if (normalizedDecision === 'local') {
+                await saveRemoteFileWithMemory(remoteName, localPayload, { uploadAttachments: true });
+                continue;
+              }
+              if (normalizedDecision === 'both') {
+                const localCloneName = `${remoteName} (local ${new Date(localModifiedAt).toISOString().slice(0, 19).replace('T', ' ')})`;
+                const remoteCloneName = `${remoteName} (cloud ${new Date(remoteModifiedAt).toISOString().slice(0, 19).replace('T', ' ')})`;
+                await saveBlocks(localCloneName, localPayload);
+                await saveRemoteFileWithMemory(localCloneName, localPayload, { uploadAttachments: true });
+                await saveBlocks(remoteCloneName, remotePayload);
+                await saveRemoteFileWithMemory(remoteCloneName, remotePayload, { uploadAttachments: true });
+                continue;
+              }
+              if (normalizedDecision === 'skip') {
+                continue;
+              }
+            }
             await saveBlocks(remoteName, remotePayload);
+            await saveRemoteFileWithMemory(remoteName, remotePayload, { uploadAttachments: true });
           }
         }
       }
@@ -1528,7 +1669,7 @@
       for (const localName of localNames) {
         if (remoteNameSet.has(localName)) continue;
         const localPayload = await loadBlocks(localName);
-        await saveRemoteFile(localName, localPayload, { uploadAttachments: true });
+        await saveRemoteFileWithMemory(localName, localPayload, { uploadAttachments: true });
       }
 
       savedList = await listSavedBlocks();
@@ -1962,6 +2103,59 @@
   overflow: hidden; /* so canvas doesn’t spill */
 }
 
+.modes.sync-lock-active {
+  pointer-events: none;
+  opacity: 0.8;
+}
+
+.sync-lock-banner {
+  position: fixed;
+  top: 72px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1300;
+  padding: 8px 12px;
+  border-radius: 10px;
+  background: rgba(255, 201, 40, 0.16);
+  border: 1px solid rgba(255, 201, 40, 0.5);
+  color: #ffd86c;
+  font-size: 0.9rem;
+}
+
+.sync-conflict-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1600;
+  display: grid;
+  place-items: center;
+}
+
+.sync-conflict-modal {
+  width: min(620px, calc(100vw - 24px));
+  background: #161820;
+  border: 1px solid #2d3344;
+  border-radius: 14px;
+  padding: 16px;
+  color: #e6e9f2;
+}
+
+.sync-conflict-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.sync-conflict-actions button {
+  border: 1px solid #39415a;
+  background: #232a3d;
+  color: #f3f6ff;
+  border-radius: 8px;
+  padding: 8px 10px;
+  cursor: pointer;
+}
+
 
 /* Optional: make it more mobile-friendly */
 /* Mobile adjustments */
@@ -2049,7 +2243,10 @@
     </div>
   {/if}
 
-  <div class="modes" role="region" aria-label="Workspace" on:dragover={handleModeDragOver} on:drop={handleModeDrop}>
+  <div class="modes" class:sync-lock-active={cloudBootstrapInProgress || cloudSyncGateInProgress} role="region" aria-label="Workspace" on:dragover={handleModeDragOver} on:drop={handleModeDrop}>
+    {#if cloudBootstrapInProgress || cloudSyncGateInProgress}
+      <div class="sync-lock-banner">Sync check in progress… editing is temporarily paused.</div>
+    {/if}
     <ModeArea
       {mode}
       blocks={modeOrderedBlocks}
@@ -2084,4 +2281,22 @@
     on:deleteTheme={handleAdvancedThemeDelete}
     on:duplicateTheme={handleAdvancedThemeDuplicate}
   />
+{/if}
+
+{#if pendingSyncConflict}
+  <div class="sync-conflict-modal-backdrop">
+    <div class="sync-conflict-modal">
+      <h3>Sync conflict detected</h3>
+      <p><strong>File:</strong> {pendingSyncConflict.fileName}</p>
+      <p>Local and cloud have different edits. Choose what to keep and sync.</p>
+      <p><small>Local modified: {new Date(pendingSyncConflict.localModifiedAt).toLocaleString()} | Cloud modified: {new Date(pendingSyncConflict.remoteModifiedAt).toLocaleString()}</small></p>
+      <p><small>Local last cloud update: {pendingSyncConflict.localLastSyncedAt ? new Date(pendingSyncConflict.localLastSyncedAt).toLocaleString() : 'Never'} | Cloud last update: {pendingSyncConflict.remoteLastSyncedAt ? new Date(pendingSyncConflict.remoteLastSyncedAt).toLocaleString() : 'Unknown'}</small></p>
+      <div class="sync-conflict-actions">
+        <button on:click={() => chooseSyncConflict('remote')}>Keep cloud version</button>
+        <button on:click={() => chooseSyncConflict('local')}>Keep local version</button>
+        <button on:click={() => chooseSyncConflict('both')}>Keep both copies</button>
+        <button on:click={() => chooseSyncConflict('skip')}>Skip for now</button>
+      </div>
+    </div>
+  </div>
 {/if}


### PR DESCRIPTION
### Motivation

- Improve cloud synchronization robustness by tracking per-file sync timestamps and prompting the user when local and cloud versions diverge.
- Prevent accidental edits during interactive sync checks by temporarily pausing the UI while cloud bootstrap/gating is in progress.

### Description

- Persist per-file cloud sync metadata to localStorage via `CLOUD_SYNC_MEMORY_STORAGE_KEY` and new helpers `loadCloudSyncMemory` and `persistCloudSyncMemory`, and track state in `cloudSyncMemoryByFile` with `rememberCloudSyncForFile`.
- Wrap remote saves with `saveRemoteFileWithMemory` to update local sync memory, and expose interactive conflict flow with `askSyncConflictChoice` and `chooseSyncConflict` plus a `pendingSyncConflict` modal UI to let users pick `remote`, `local`, `both`, or `skip`.
- Update sync logic in `pullRemoteUpdatesIfNeeded` and `bootstrapCloudSync` to use last-synced timestamps and to invoke interactive resolution when cloud/newness is ambiguous, and switch calls to use `saveRemoteFileWithMemory`.
- Add sync gating state (`cloudSyncGateInProgress`) and UI lock/banner by binding `.sync-lock-active` on the workspace and adding styles and a conflict modal markup; also refine autosync behavior in `autoSyncUploadTick` and `toggleAutoSync` to bootstrap interactive sync when enabling auto-sync.

### Testing

- Ran project build and smoke-start to ensure the app compiles and the UI renders without errors, and the new modal/banner appear during simulated conflict scenarios (build succeeded).
- Executed the existing automated test suite and verified tests passed (no sync-specific unit tests were added in this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb38d78484832ea1309261f4d3aa14)