### PR TITLE
Refresh mounted save when cloud version is applied during sync enable

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1567,6 +1567,7 @@
     ]);
     const remoteNames = Object.keys(remoteIndex || {});
     const unionNames = new Set([...localNames, ...remoteNames]);
+    let localFilesChangedFromCloud = false;
 
     for (const fileName of unionNames) {
       const hasLocal = localNames.includes(fileName);
@@ -1577,6 +1578,7 @@
       const remoteModifiedAt = Number(remotePayload?.modifiedAt || remotePayload?.updatedAt || 0);
       if (!hasLocal && hasRemote && remotePayload) {
         await saveBlocks(fileName, remotePayload);
+        localFilesChangedFromCloud = true;
         continue;
       }
       if (hasLocal && !hasRemote && localPayload) {
@@ -1606,7 +1608,13 @@
         await saveRemoteFileWithMemory(remoteCloneName, remotePayload, { uploadAttachments: true });
       } else if (decision === 'remote') {
         await saveBlocks(fileName, remotePayload);
+        localFilesChangedFromCloud = true;
       }
+    }
+
+    if (localFilesChangedFromCloud) {
+      savedList = await listSavedBlocks();
+      await remountCurrentSaveIfLoaded();
     }
   }
 


### PR DESCRIPTION
### Motivation
- Enabling cloud sync and choosing the cloud version could update local files without updating the mounted editor state, leaving the UI showing stale content.
- The reconciliation logic needs to detect when cloud data created or overwrote local files and refresh the UI accordingly.

### Description
- Added a `localFilesChangedFromCloud` flag to `reconcileDiffsOnAutoSyncEnable()` in `src/App.svelte` to track when cloud data modifies or creates local files.
- Mark the flag when downloading cloud-only files (`saveBlocks(fileName, remotePayload)`) or when a conflict resolution chooses the remote/cloud version (`decision === 'remote'`).
- After reconciliation, if the flag is set, refresh the local save list with `savedList = await listSavedBlocks()` and call `await remountCurrentSaveIfLoaded()` to remount the current save so the UI immediately reflects cloud-applied changes.

### Testing
- Ran the production build with `npm run -s build`, which completed successfully.
- No new build errors introduced; existing Svelte warnings unrelated to this change remain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb4a685a88832e836d6523ac402856)