### PR TITLE
Remove manual save button from left controls

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1209,23 +1209,6 @@
   function handleModeDragOver(event) {
     event.preventDefault();
   }
-  async function save() {
-    const trimmedName = currentSaveName.trim();
-    if (!trimmedName) {
-      return;
-    }
-
-    if (trimmedName !== currentSaveName) {
-      currentSaveName = trimmedName;
-    }
-
-    if (hasUnsnapshottedChanges) {
-      await pushHistory(blocks, modeOrders);
-    } else {
-      await persistAutosave(blocks, modeOrders);
-      hasUnsnapshottedChanges = false;
-    }
-  }
 
   async function createNewFile() {
     const proposedName = window.prompt('Enter a name for the new file:');
@@ -2089,7 +2072,6 @@
       {birthdayUnlockMessage}
       on:addBlock={(e) => addBlock(e.detail)}
       on:clear={clear}
-      on:save={save}
       on:exportJSON={exportJSON}
       on:importJSON={(e) => importJSON(e.detail)}
       on:setMode={(e) => setMode(e.detail)}

--- a/src/advanced-param/LeftControls.svelte
+++ b/src/advanced-param/LeftControls.svelte
@@ -71,9 +71,6 @@
     dispatch("clear");
   }
 
-  function save() {
-    dispatch("save");
-  }
 
   function exportJSON() {
     dispatch("exportJSON");
@@ -626,7 +623,6 @@ onMount(() => {
       style="display: none"
     />
     <input bind:value={currentSaveName} placeholder="File name" />
-    <button on:click={save}>💾 Save</button>
     {#if isSimpleNoteMode}
       <label class="simple-columns-control mobile-only">
         Columns


### PR DESCRIPTION
### Motivation
- The UI exposes a manual `Save` control that is redundant now that autosave/persist behavior handles saving automatically, so the manual button and its event plumbing were removed to simplify the controls panel.

### Description
- Removed the `💾 Save` button from `src/advanced-param/LeftControls.svelte` and the associated `save()` dispatch from that component.
- Removed the `on:save={save}` listener prop from the `LeftControls` usage in `src/App.svelte` and deleted the now-unused `save()` handler in `src/App.svelte`.
- Left the filename input and other file-related actions intact so autosave and explicit create/load/delete flows continue to work.

### Testing
- Ran the production build with `npm run build` which completed successfully (Svelte a11y/style warnings were reported but are unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb65d57438832e8cc75e386a3c2cb2)