### PR TITLE
Expand canvas edge-pan zone and enable Ctrl-edge pan when canvas overflows

### DIFF
--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -26,7 +26,7 @@
   const MIN_ZOOM = 0.2;
   const MAX_ZOOM = 4;
   const WHEEL_ZOOM_SENSITIVITY = 0.0015;
-  const EDGE_PAN_ZONE = 240;
+  const EDGE_PAN_ZONE = 480;
   const EDGE_PAN_MAX_SPEED = 50;
 
   let scale = 1;
@@ -220,9 +220,19 @@
     edgePanRaf = requestAnimationFrame(stepEdgePan);
   }
 
+
+  function canCtrlEdgePan() {
+    if (!canvasRef) return false;
+
+    const canScrollHorizontally = canvasRef.scrollWidth > canvasRef.clientWidth;
+    const canScrollVertically = canvasRef.scrollHeight > canvasRef.clientHeight;
+
+    return scale > getViewportScaleFloor() || canScrollHorizontally || canScrollVertically;
+  }
+
   function updateEdgePanFromPointer(event) {
     if (!canvasRef) return;
-    if (!event.ctrlKey || scale <= getViewportScaleFloor()) {
+    if (!event.ctrlKey || !canCtrlEdgePan()) {
       stopEdgePan();
       return;
     }


### PR DESCRIPTION
### Motivation
- Improve the canvas panning UX by enlarging the edge pan activation region so users can more easily trigger panning near edges.
- Allow Ctrl+pointer edge-pan to work not only when the canvas is zoomed in, but also when the canvas content overflows the viewport (scrollbars present), so users can pan even at fit-to-viewport scale.

### Description
- Increased the edge pan zone by changing `EDGE_PAN_ZONE` from `240` to `480` in `src/Modes/CanvasMode.svelte` so the pan area is twice as large.
- Added a new helper `canCtrlEdgePan()` that returns true when either `scale > getViewportScaleFloor()` or the canvas can scroll horizontally/vertically (i.e., `canvasRef.scrollWidth > canvasRef.clientWidth` or `canvasRef.scrollHeight > canvasRef.clientHeight`).
- Replaced the previous gating check `scale <= getViewportScaleFloor()` with `!canCtrlEdgePan()` in `updateEdgePanFromPointer()` so Ctrl-based edge panning activates when overflow exists even if not zoomed in.

### Testing
- Ran the production build with `npm run build` and the build completed successfully.
- The build reported existing unrelated Svelte warnings (unused CSS selector and a11y warnings in other components) but no errors caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0947bd3ad0832e9d2b28d069ed3599)