### PR TITLE
Keep sync lock active until post-download remount completes

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1550,12 +1550,15 @@
     if (downloadInProgress) return;
 
     downloadInProgress = true;
+    cloudSyncGateInProgress = true;
     try {
       await pullRemoteUpdatesIfNeeded({ showInfo: true });
+      await remountCurrentSaveIfLoaded();
     } catch (error) {
       console.error(error);
       alert(`Download failed: ${error?.message || error}`);
     } finally {
+      cloudSyncGateInProgress = false;
       downloadInProgress = false;
     }
   }


### PR DESCRIPTION
### Motivation
- Prevent UI/editing from being re-enabled before post-download sync checks and remount finish so the open folder reflects any downloaded changes. 
- Ensure the currently opened save is reloaded after cloud downloads so users immediately see updated files.

### Description
- Hold the workspace sync lock by setting `cloudSyncGateInProgress = true` at the start of `downloadAllCloudToLocal()` and releasing it in the `finally` block. 
- Call `await remountCurrentSaveIfLoaded()` after `pullRemoteUpdatesIfNeeded({ showInfo: true })` so the active save is reloaded if it was updated by the download. 
- Ensure both `cloudSyncGateInProgress` and `downloadInProgress` are always cleared in the `finally` path to avoid leaving the UI locked on errors; changes are in `src/App.svelte`.

### Testing
- Ran `npm run build` and the production build completed successfully (warnings only), indicating the change compiles and bundles correctly.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0aa409e268832eba2a0761b448bfab)