### PR TITLE
Skip canvas wheel override when wheel originates in nested scrollable child

### DIFF
--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -173,10 +173,38 @@
   }
 
 
+  function shouldLetNestedScrollerHandleWheel(event) {
+    if (!canvasRef) return false;
+
+    let current = event.target;
+    while (current && current !== canvasRef) {
+      if (!(current instanceof Element)) {
+        current = current?.parentElement;
+        continue;
+      }
+
+      const style = getComputedStyle(current);
+      const overflowY = style.overflowY;
+      const overflowX = style.overflowX;
+      const canScrollY = (overflowY === 'auto' || overflowY === 'scroll') && current.scrollHeight > current.clientHeight;
+      const canScrollX = (overflowX === 'auto' || overflowX === 'scroll') && current.scrollWidth > current.clientWidth;
+
+      if (canScrollY || canScrollX) {
+        return true;
+      }
+
+      current = current.parentElement;
+    }
+
+    return false;
+  }
+
   function onWheel(event) {
     if (!canvasRef) return;
 
     if (!event.ctrlKey) {
+      if (shouldLetNestedScrollerHandleWheel(event)) return;
+
       const canScrollHorizontally = canvasRef.scrollWidth > canvasRef.clientWidth;
       const canScrollVertically = canvasRef.scrollHeight > canvasRef.clientHeight;
       const hasSingleScrollableAxis = canScrollHorizontally !== canScrollVertically;


### PR DESCRIPTION
### Motivation
- Non-`Ctrl` wheel events were cancelling native scrolling and forcing canvas scroll even when the event came from a nested scrollable control (e.g. text editors), causing a regression in nested scrolling behavior.

### Description
- Added `shouldLetNestedScrollerHandleWheel(event)` to `src/Modes/CanvasMode.svelte` and updated `onWheel()` to early-return for non-`Ctrl` wheel events that originate from a nested scrollable descendant so the child element keeps its native wheel behavior instead of the canvas hijacking the event.

### Testing
- Ran `npm run build` and the production build completed successfully.
- Attempted `npm test -- --runInBand` but the repository has no `test` script defined so automated tests were not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab183737c832e9ed0da4506381ebf)