### PR TITLE
Allow nested scrollable elements to handle wheel events in CanvasMode

### DIFF
--- a/src/Modes/CanvasMode.svelte
+++ b/src/Modes/CanvasMode.svelte
@@ -173,10 +173,36 @@
   }
 
 
+  function shouldLetNestedScrollerHandleWheel(event) {
+    if (!canvasRef || !(event.target instanceof Element)) return false;
+
+    const focusedBlock = event.target.closest('[aria-pressed="true"]');
+    if (!focusedBlock || !canvasRef.contains(focusedBlock)) return false;
+
+    let current = event.target;
+    while (current && current !== focusedBlock) {
+      const style = getComputedStyle(current);
+      const overflowY = style.overflowY;
+      const overflowX = style.overflowX;
+      const canScrollY = (overflowY === 'auto' || overflowY === 'scroll') && current.scrollHeight > current.clientHeight;
+      const canScrollX = (overflowX === 'auto' || overflowX === 'scroll') && current.scrollWidth > current.clientWidth;
+
+      if (canScrollY || canScrollX) {
+        return true;
+      }
+
+      current = current.parentElement;
+    }
+
+    return false;
+  }
+
   function onWheel(event) {
     if (!canvasRef) return;
 
     if (!event.ctrlKey) {
+      if (shouldLetNestedScrollerHandleWheel(event)) return;
+
       const canScrollHorizontally = canvasRef.scrollWidth > canvasRef.clientWidth;
       const canScrollVertically = canvasRef.scrollHeight > canvasRef.clientHeight;
       const hasSingleScrollableAxis = canScrollHorizontally !== canScrollVertically;


### PR DESCRIPTION
### Motivation

- Prevent the canvas from hijacking wheel scrolls when a nested, focused block contains its own scrollable area, while retaining existing pinch-zoom and `Ctrl`+wheel zoom behavior.
- Improve UX for embedded scrollable content so inner scrollers can receive wheel events when appropriate.

### Description

- Added `shouldLetNestedScrollerHandleWheel(event)` which checks the event target's closest focused block and walks up from the event target to that block to detect scrollable elements via `getComputedStyle` and element size checks.
- Updated `onWheel` to early-return when `shouldLetNestedScrollerHandleWheel(event)` is true for non-`Ctrl` wheel events, allowing nested scrollers to handle scrolling.
- Kept existing canvas-only scroll behavior and `Ctrl`+wheel zoom handling intact by leaving the prior scroll and zoom logic unchanged.

### Testing

- Ran unit tests with `npm test`, and the test suite passed.
- Ran linting with `npm run lint`, and no lint errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ab183737c832e9ed0da4506381ebf)